### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,22 @@
-PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man/man1
-DOCDIR=$(PREFIX)/share/doc/buku
-UNAME_S:=$(shell uname -s)
+PREFIX?=	/usr/local
+BINDIR?=	$(PREFIX)/bin
+MANDIR?=	$(PREFIX)/share/man/man1
+DOCDIR?=	$(PREFIX)/share/doc/buku
 
 
 .PHONY: install uninstall
 
 install:
-	install -m755 -d $(BINDIR)
-	install -m755 -d $(MANDIR)
-	install -m755 -d $(DOCDIR)
+	install -m755 -d $(DESTDIR)$(BINDIR)
+	install -m755 -d $(DESTDIR)$(MANDIR)
+	install -m755 -d $(DESTDIR)$(DOCDIR)
 	gzip -c buku.1 > buku.1.gz
-	@if [ "$(UNAME_S)" = "Linux" ]; then\
-		install -m755 -t $(BINDIR) buku; \
-		install -m644 -t $(MANDIR) buku.1.gz; \
-		install -m644 -t $(DOCDIR) README.md; \
-	fi
-	@if [ "$(UNAME_S)" = "Darwin" ]; then\
-		install -m755  buku $(BINDIR); \
-		install -m644  buku.1.gz $(MANDIR); \
-		install -m644  README.md $(DOCDIR); \
-	fi
+	install -m755 buku $(DESTDIR)$(BINDIR)
+	install -m644 buku.1.gz $(DESTDIR)$(MANDIR)
+	install -m644 README.md $(DESTDIR)$(DOCDIR)
 	rm -f buku.1.gz
 
 uninstall:
-	rm -f $(BINDIR)/buku
-	rm -f $(MANDIR)/buku.1.gz
-	rm -rf $(DOCDIR)
+	rm -f $(DESTDIR)$(BINDIR)/buku
+	rm -f $(DESTDIR)$(MANDIR)/buku.1.gz
+	rm -rf $(DESTDIR)$(DOCDIR)


### PR DESCRIPTION
- Make install directories overridable (user may want another PREFIX; some systems use ```${PREFIX}/man``` MANDIR instead of ```${PREFIX}/share/man```
- Support DESTDIR
- Simplify installation (install syntax is pretty much standard everywhere, no need to differentiate based on uname)

This works well on FreeBSD with both GNU make and BSD make (nmake, fmake)