### PR TITLE
added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.4.1
+pycrypto==2.6.1


### PR DESCRIPTION
Since you've started adding libs, might as well specify them in requirements.txt so that people can easily install them (with `pip install -r requirements.txt`).
I usually pin the exact version to be on the safe side (most devs will use virtualenvs anyway), but if you don't like it you can change it to the slightly more fragile `>=`