### PR TITLE
Testing enhancements

### DIFF
--- a/buku
+++ b/buku
@@ -446,21 +446,6 @@ class BukuDb:
         :tag_manual: string of comma-separated tags to add manually
         """
 
-        self.select_tags_from_bookmarks(index)
-        resultset = self.cur.fetchall()
-        for row in resultset:
-            tags = '%s%s' % (row[1], tag_manual[1:])
-            tags = parse_tags([tags])
-            self.cur.execute('UPDATE bookmarks SET tags = ? WHERE id = ?', (tags, row[0],))
-
-        self.conn.commit()
-
-    def select_tags_from_bookmarks(self, index):
-        """ Select either the tags for one bookmark or all bookmarks
-
-        :param index: int position of record, 0 for all
-        """
-
         if index == 0:
             resp = input('Tags will be appended for ALL bookmarks. Enter \x1b[1my\x1b[21m to confirm: ')
             if resp != 'y':
@@ -469,6 +454,14 @@ class BukuDb:
             self.cur.execute('SELECT id, tags FROM bookmarks ORDER BY id ASC')
         else:
             self.cur.execute('SELECT id, tags FROM bookmarks WHERE id = ?', (index,))
+
+        resultset = self.cur.fetchall()
+        for row in resultset:
+            tags = '%s%s' % (row[1], tag_manual[1:])
+            tags = parse_tags([tags])
+            self.cur.execute('UPDATE bookmarks SET tags = ? WHERE id = ?', (tags, row[0],))
+
+        self.conn.commit()
 
     def delete_tag_at_index(self, index, tag_manual):
         """ Delete tags for bookmark at index

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -276,8 +276,11 @@ class TestBukuDb(unittest.TestCase):
         # deleting all bookmarks
         self.bdb.delete_all_bookmarks()
         # assert table has been dropped
-        with self.assertRaises(sqlite3.OperationalError):
+        with self.assertRaises(sqlite3.OperationalError) as ctx_man:
             self.bdb.get_bookmark_by_index(0)
+
+        err_msg = str(ctx_man.exception)
+        self.assertEqual(err_msg, 'no such table: bookmarks')
 
     # @unittest.skip('skipping')
     def test_replace_tag(self):

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -39,6 +39,8 @@ TEST_BOOKMARKS = [ ['http://slashdot.org',
                     ],
 ]
 
+inclusive_range = lambda start, end: range(start, end + 1)
+
 @pytest.fixture()
 def setup():
     os.environ['XDG_DATA_HOME'] = TEST_TEMP_DIR_PATH
@@ -144,7 +146,8 @@ class TestBukuDb(unittest.TestCase):
             self.assertIsNotNone(from_db)
             # comparing data
             for pair in zip(from_db[1:], bookmark):
-                self.assertEqual(*pair)
+                with self.subTest(from_db=from_db[1:], bookmark=bookmark):
+                    self.assertEqual(*pair)
 
         # TODO: tags should be passed to the api as a sequence...
 
@@ -161,9 +164,11 @@ class TestBukuDb(unittest.TestCase):
         # retrieving bookmark from database
         from_db = self.bdb.get_bookmark_by_index(index)
         self.assertIsNotNone(from_db)
+
         # checking if values are updated
         for pair in zip(from_db[1:], new_values):
-            self.assertEqual(*pair)
+            with self.subTest(from_db=from_db[1:], new_values=new_values):
+                self.assertEqual(*pair)
 
     # @unittest.skip('skipping')
     def test_append_tag_at_index(self):
@@ -171,23 +176,27 @@ class TestBukuDb(unittest.TestCase):
             self.bdb.add_bookmark(*bookmark)
 
         # tags to add
-        old_tags = self.bdb.get_bookmark_by_index(1)[3]
         new_tags = ",foo,bar,baz"
-        self.bdb.append_tag_at_index(1, new_tags)
-        # updated list of tags
-        from_db = self.bdb.get_bookmark_by_index(1)[3]
 
-        # checking if new tags were added to the bookmark
-        self.assertTrue(all( x in from_db.split(',') for x in new_tags.split(',') ))
-        # checking if old tags still exist
-        self.assertTrue(all( x in from_db.split(',') for x in old_tags.split(',') ))
+        for idx, bookmark in enumerate(self.bookmarks):
+            bm_index = idx + 1
+            old_tags = self.bdb.get_bookmark_by_index(bm_index)[3]
+            # adding tags to existing
+            self.bdb.append_tag_at_index(bm_index, new_tags)
+            # get updated set of tags
+            from_db = self.bdb.get_bookmark_by_index(bm_index)[3]
+
+            with self.subTest(old_tags=old_tags, updated_tags=from_db):
+                # checking if new tags were added to the bookmark
+                self.assertTrue(all( x in from_db.split(',') for x in new_tags.split(',') ))
+                # checking if old tags still exist
+                self.assertTrue(all( x in from_db.split(',') for x in old_tags.split(',') ))
 
     # @unittest.skip('skipping')
     def test_append_tag_at_all_indices(self):
         for bookmark in self.bookmarks:
             self.bdb.add_bookmark(*bookmark)
 
-        inclusive_range = lambda start, end: range(start, end + 1)
         # tags to add
         new_tags = ",foo,bar,baz"
         # record of original tags for each bookmark
@@ -198,10 +207,11 @@ class TestBukuDb(unittest.TestCase):
             # updated tags for each bookmark
             from_db = [ (i, self.bdb.get_bookmark_by_index(i)[3]) for i in inclusive_range(1, len(self.bookmarks)) ]
             for index, tagset in from_db:
-                # checking if new tags added to bookmark
-                self.assertTrue(all( x in tagset.split(',') for x in new_tags.split(',') ))
-                # checking if old tags still exist for boomark
-                self.assertTrue(all( x in tagset.split(',') for x in old_tagsets[index].split(',') ))
+                with self.subTest():
+                    # checking if new tags added to bookmark
+                    self.assertTrue(all( x in tagset.split(',') for x in new_tags.split(',') ))
+                    # checking if old tags still exist for boomark
+                    self.assertTrue(all( x in tagset.split(',') for x in old_tagsets[index].split(',') ))
 
 
     # @unittest.skip('skipping')
@@ -210,17 +220,18 @@ class TestBukuDb(unittest.TestCase):
         for bookmark in self.bookmarks:
             self.bdb.add_bookmark(*bookmark)
 
-        inclusive_range = lambda start, end: range(start, end + 1)
         # dictionary of db bookmark index: tags
-        tags_by_index = { i: self.bdb.get_bookmark_by_index(i)[3] for i in inclusive_range(1, len(self.bookmarks)) }
+        tagsets = [ self.bdb.get_bookmark_by_index(i)[3] for i in inclusive_range(1, len(self.bookmarks)) ]
 
-        for i, tags in tags_by_index.items():
+        for i, tags in enumerate(tagsets):
+            idx = i + 1
             # get the first tag from the bookmark
             to_delete = re.match(',.*?,', tags).group(0)
-            self.bdb.delete_tag_at_index(i, to_delete)
+            self.bdb.delete_tag_at_index(idx, to_delete)
             # get updated tags from db
-            from_db = self.bdb.get_bookmark_by_index(i)[3]
-            self.assertNotIn(to_delete, from_db)
+            from_db = self.bdb.get_bookmark_by_index(idx)[3]
+            with self.subTest(to_delete=to_delete, updated_tags=from_db):
+                self.assertNotIn(to_delete, from_db)
 
     # @unittest.skip('skipping')
     def test_refreshdb(self):


### PR DESCRIPTION
* Using `unittest.subTest` to make sure assertions inside each iteration are tested, even if earlier ones fail.
* Moving select_tag_from_bookmarks back into append_tag since; not really useful since input functions aren't being passed to methods. This also maintains more symmetry with other similar methods.
