### PR TITLE
Change --help output to STDOUT rather than STDERR

### DIFF
--- a/buku
+++ b/buku
@@ -1976,7 +1976,7 @@ if __name__ == '__main__':
 
     # Show help and exit if no arguments
     if len(sys.argv) < 2:
-        argparser.print_help(sys.stderr)
+        argparser.print_help(sys.stdout)
         sys.exit(1)
 
     # Parse the arguments
@@ -1984,7 +1984,7 @@ if __name__ == '__main__':
 
     # Show help and exit if help requested
     if args.help:
-        argparser.print_help(sys.stderr)
+        argparser.print_help(sys.stdout)
         sys.exit(0)
 
     # Assign the values to globals


### PR DESCRIPTION
I tried running "buku --help | less" to better view the --help page, but to find that it doesn't work. --help is going through sys.stderr rather than sys.stdout. I'm not sure if there was a reason for this, but it's highly unusual. 