### PR TITLE
Support http proxy environment variables

### DIFF
--- a/buku.1
+++ b/buku.1
@@ -222,6 +222,20 @@ Exit buku.
 .BI BROWSER
 Overrides the default browser. Ref:
 .I http://docs.python.org/library/webbrowser.html
+.TP
+.BR http_proxy ", " HTTP_PROXY ", " https_proxy "  or " HTTPS_PROXY"
+
+If defined, will be used to access http and https resources through the configured proxy. 
+For https requests, if https proxy is not defined but http is, the latter will be used 
+instead. 
+
+They should be in the following format:
+
+    http[s]://proxyhost:proxyport
+
+Buku uses urllib3 for proxy support, but that library doesn't support authenticated
+proxies. So, if that's your need, you should use a local intermediate proxy, such as 
+cntlm, TinyProxy or Polipo.
 .SH EXAMPLES
 .PP
 .IP 1. 4

--- a/buku.py
+++ b/buku.py
@@ -1492,6 +1492,37 @@ def get_page_title(resp):
         return htmlparser.parsed_title
 
 
+def create_poolmanager(url):
+    '''Creates a pool manager with proxy support, if needed.
+    
+    Checks to see if there are proxy variables defined and creates
+    a ProxyManager. If not, creates a PoolManager.
+    '''
+
+    # Check if http_proxy or HTTP_PROXY is defined
+    http_proxy = os.environ.get('http_proxy')
+    if not http_proxy:
+        http_proxy = os.environ.get('HTTP_PROXY')
+
+    # Check if https_proxy or HTTPS_PROXY is defined
+    https_proxy = os.environ.get('https_proxy')
+    if not https_proxy:
+        https_proxy = os.environ.get('HTTPS_PROXY')
+
+    # If not, falls back to http_proxy, which is more common.
+    if not https_proxy:
+        https_proxy = http_proxy
+
+    # Create a pool manager with or without proxy support as needed.
+    if url.startswith('http://') and http_proxy:
+        manager = urllib3.ProxyManager(http_proxy)
+    elif url.startswith('https://') and https_proxy:
+        manager = urllib3.ProxyManager(https_proxy)
+    else:
+        manager = urllib3.PoolManager()
+    return manager;
+
+
 def network_handler(url):
     '''Handle server connection and redirections
 
@@ -1513,7 +1544,7 @@ def network_handler(url):
 
     if not http_handler:
         urllib3.disable_warnings()
-        http_handler = urllib3.PoolManager()
+        http_handler = create_poolmanager(url)
 
     try:
         while True:


### PR DESCRIPTION
Hi, I would like to be able to use Buku behind an enterprise proxy. urllib3 already has support for that, but need to be configured when creating an pool manager. This patch does that configuration. All that is needed is some environment variables (http_proxy, https_proxy, etc) that are already nsed by other tools, such as curl, wget, etc.