### PR TITLE
draft: multithreaded refreshdb

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -777,9 +777,7 @@ class BukuDb:
         LOCK = threading.Lock()
 
         def refresh():
-            '''call network_handler and update db
-
-            :param db: a BukuDb object
+            '''helper function to call network_handler and update db
             '''
 
             while len(resultset) > 0:
@@ -796,10 +794,9 @@ class BukuDb:
                     print('\x1b[1mIndex %d: no title\x1b[0m\n' % row[0])
                     continue
 
-                
                 LOCK.acquire()
-                self.cur.execute(query, (title, row[0],))
-                self.conn.commit() 
+                self.cur.execute(query, (title, row[0],)) # the connection is closed
+                self.conn.commit()
                 LOCK.release()
 
                 if self.chatty:
@@ -816,7 +813,6 @@ class BukuDb:
             thread.start()
 
         return True
-
 
     def searchdb(self, keywords, all_keywords=False, deep=False, regex=False):
         '''Search the database for an entries with tags or URL
@@ -2562,7 +2558,7 @@ def main():
         bdb.fixtags()
 
     # Close DB connection and quit
-    bdb.close_quit(0)
+    # bdb.close_quit(0)
 
 if __name__ == '__main__':
     main()

--- a/buku.py
+++ b/buku.py
@@ -777,7 +777,7 @@ class BukuDb:
         LOCK = threading.Lock()
 
         def refresh():
-            '''helper function to call network_handler and update db
+            '''Fetch title and update the records.
             '''
 
             while len(resultset) > 0:
@@ -795,8 +795,10 @@ class BukuDb:
                     continue
 
                 LOCK.acquire()
-                self.cur.execute(query, (title, row[0],)) # the connection is closed
+                self.cur.execute(query, (title, row[0],))
                 self.conn.commit()
+                if interrupted:
+                    return True
                 LOCK.release()
 
                 if self.chatty:
@@ -804,8 +806,6 @@ class BukuDb:
                           % (title, row[0]))
                 '''
                 # do we need this?
-                if interrupted:
-                    break
                 '''
 
         for thread in range(4):
@@ -2556,9 +2556,6 @@ def main():
     # Fix tags
     if args.fixtags:
         bdb.fixtags()
-
-    # Close DB connection and quit
-    # bdb.close_quit(0)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I included two versions of refreshdb.
The first one uses one connection per thread, and the second one has the threads share a single connection

I added the timeout and check_same_thread args to all sqlite3.connect statments   
timeout was to prevent a thread from locking the DB while waiting on another thread. 
check_same_thread was supposed to let me share a connection across threads

I get them same error for both the single connection and multi-connection versions
sqlite3.ProgrammingError: Cannot operate on a closed cursor.

While playing around I got some similar errors 
sqlite3 ProgrammingErrors : Can't operate on a closed database. 
sqlite3.OperationalError: database is locked
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.

Also, you mentioned getting rid of the overriden fetch method. What class is it a method of?