### PR TITLE
fixed ZSH syntax error for auto completion

### DIFF
--- a/auto-completion/zsh/_buku
+++ b/auto-completion/zsh/_buku
@@ -15,7 +15,7 @@ args=(
     '(--deep)--deep[search matching substrings]'
     '(-e --export)'{-e,--export}'[export bookmarks]:html output file'
     '(--expand)--expand[expand a tny.im shortened URL]:index/shorturl'
-    '(-f --format)'{-f,--format}'[limit fields in print and Json output:value'
+    '(-f --format)'{-f,--format}'[limit fields in print and Json output]:value'
     '(-h --help)'{-h,--help}'[show help]'
     '(-i --import)'{-i,--import}'[import bookmarks]:html imput file'
     '(--immutable)--immutable[disable title update from web]:value'


### PR DESCRIPTION
fixes
`_arguments:comparguments:319: invalid option definition: (-f --format)-f[limit fields in print and Json output:value`
in ZSH autocompletion file