### PR TITLE
Added --openall option

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2294,13 +2294,16 @@ POSITIONAL ARGUMENTS:
     --deep               match substrings ('pen' matches 'opens')
     --sreg               run a regex search
     --stag               search bookmarks by a tag
-                         list all tags, if no search keywords''')
+                         list all tags, if no search keywords
+    --openall            immediately opens all search results 
+                         in browser, works best with --noprompt''')
     addarg = search_grp.add_argument
     addarg('-s', '--sany', action='store_true', help=HIDE)
     addarg('-S', '--sall', action='store_true', help=HIDE)
     addarg('--sreg', action='store_true', help=HIDE)
     addarg('--deep', action='store_true', help=HIDE)
     addarg('--stag', action='store_true', help=HIDE)
+    addarg('--openall', action='store_true', help=HIDE)
 
     # ------------------------
     # ENCRYPTION OPTIONS GROUP
@@ -2485,6 +2488,16 @@ POSITIONAL ARGUMENTS:
     if search_results:
         oneshot = args.noprompt
         to_delete = False
+
+        # Open all results in browser right away,
+        # has priority over delete/update, i.e. URLs
+        # can be opened and deleted/updated after     
+        if args.openall:   
+            for row in search_results:
+                try:
+                    open_in_browser(row[1])
+                except Exception as e:
+                    logerr('main() 1: %s', e)
 
         # In case of search and delete/update,
         # prompt should be non-interactive


### PR DESCRIPTION
This is a small patch, which adds an --openall option. The idea is to be able to immediately open all search results without an extra step. Works best with --noprompt.

For example, the following line will open all my news sites:

`$ buku --openall --noprompt -s news
1. https://www.heise.de [3]
   > heise online - IT-News, Nachrichten und Hintergründe
   # news,technik

2. https://www.golem.de [4]
   > Golem.de: IT-News für Profis
   # news,technik

3. https://www.spiegel.de [5]
   > SPIEGEL ONLINE - Aktuelle Nachrichten
   # news`

For me, this is very useful!