### PR TITLE
Add completion for --stags

### DIFF
--- a/auto-completion/bash/buku-completion.bash
+++ b/auto-completion/bash/buku-completion.bash
@@ -64,6 +64,11 @@ _buku () {
         --url
     )
 
+    if [ "$prev" == "--stag" ]; then
+        COMPREPLY=( $(compgen -W "$(buku --completion tags)" -- "$cur") )
+        return 0
+    fi
+
     # Do not complete non option names
     [[ $cur == -* ]] || return 1
 

--- a/buku.py
+++ b/buku.py
@@ -2496,6 +2496,8 @@ POSITIONAL ARGUMENTS:
     addarg('-h', '--help', action='store_true', help=HIDE)
     addarg('-v', '--version', action='version', version=__version__, help=HIDE)
 
+    addarg('--completion', nargs=1, help=HIDE)
+
     # ------------------
     # EDIT OPTIONS GROUP
     # ------------------
@@ -2676,6 +2678,16 @@ POSITIONAL ARGUMENTS:
     # Initialize the database and get handles, set verbose by default
     bdb = BukuDb(args.json, args.format, not args.tacit,
                  colorize=not args.nc)
+
+    # Provide data to our completion engine
+    if args.completion:
+        completion_type = args.completion[0]
+        if completion_type == 'tags':
+            tags = bdb.get_all_tags()
+            print(" ".join(tags[0]))
+            bdb.close_quit(0)
+
+        bdb.close_quit(1)
 
     # Editor mode
     if args.write is not None:


### PR DESCRIPTION
- Description
Provide completion engine for --stags such that it returns all the existing tags in your database
- Design notes
This adds a new command line flags `--completion` which takes in the type of completions that you need (in this case tags) and returns the list of strings
- Side effects
Tags with spaces will create problems, since completion engine is space delimited.
I only manage to add to bash as it is the shell i am using, but i believe that other shell should be able to integrate this easily as I am calling the buku.py to resolve the values.

Note: This is currently incomplete as it lacks readme and documentation. Just curious if anyone else is interested in the idea. I added this quite a while ago.

