### PR TITLE
Feature/tox test

### DIFF
--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -68,6 +68,7 @@ class TestBukuDb(unittest.TestCase):
         os.environ['XDG_DATA_HOME'] = TEST_TEMP_DIR_PATH
 
     # @unittest.skip('skipping')
+    @pytest.mark.non_tox
     def test_get_default_dbdir(self):
         dbdir_expected = TEST_TEMP_DBDIR_PATH
         dbdir_local_expected = os.path.join(os.path.expanduser('~'), '.local', 'share', 'buku')

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -226,6 +226,7 @@ class TestBukuDb(unittest.TestCase):
             self.assertNotIn(to_delete, from_db)
 
     # @unittest.skip('skipping')
+    @pytest.mark.slowtest
     def test_refreshdb(self):
         self.bdb.add_rec("https://www.google.com/ncr", "?")
         self.bdb.refreshdb(1, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = python33,python34,python35
+
+[testenv]
+deps=
+    pytest
+    pytest-cov
+    pytest-catchlog
+commands =
+    pip install -r requirements.txt
+    pytest --cov buku -vv {posargs}
+    ;pytest --cov buku -vv -m 'not slowtest and not non_tox'{posargs}


### PR DESCRIPTION
this add tox config for any developer who want to test program with several python version. i also add a commented test command on `tox.ini`, so people can run faster test by using it.

there is also several pytest mark which i added because following reason:

- `non_tox` on `test_get_default_dbdir`: tox can't get the actual path here, but pytest can.
- `slowtest` on `test_refreshdb`: the refreshdb take a long time for me, so i add it. this can also be an example if any of future test take a long time and need to be skipped on full test

there is no meaningful change on pytest/travis

related #133