### PR TITLE
Threading for webbrowser on Win32 (partially fixes #142 for good).

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2245,7 +2245,14 @@ def browse(url):
     os.dup2(fd, 2)
     os.dup2(fd, 1)
     try:
-        webbrowser.open(url, new=2)
+        if sys.platform != 'win32':
+            webbrowser.open(url, new=2)
+        else:
+            # On Windows, the webbrowser module does not fork.
+            # Use threads instead.
+            browserthread = lambda: webbrowser.open(url, new=2)
+            t = threading.Thread(target=browserthread)
+            t.start()
     except Exception as e:
         logerr('browse(): %s', e)
     finally:


### PR DESCRIPTION
Tested on Vivaldi (Chrome-based), qutebrowser (PyWebKit-based), Pale Moon (Firefox fork) and Firefox Developer Edition. It works as intended *if* the current default browser (or whatever Buku thinks the default browser is) is actively running. Depending on the browser, it still only opens everything in one tab if it is *not* running yet. But who closes his browser anyway? :-)