### PR TITLE
Feature/test non generic url

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ SYMBOLS:
   - --stag : search bookmarks by a tag, or list all tags alphabetically with usage count (if no arguments).
   - Search results are indexed serially. This index is different from actual database index of a bookmark record which is shown within `[]` after the title.
 - **Import**:
-  - URLs starting with `place:`, `file://` and `apt://` are ignored during import.
+  - URLs starting with `place:`, `file://` and `apt:` are ignored during import.
 - **Encryption** is optional and manual. AES256 algorithm is used. To use encryption, the database file should be unlocked (-k) before using `buku` and locked (-l) afterwards. Between these 2 operations, the database file lies unencrypted on the disk, and NOT in memory. Also, note that the database file is *unencrypted on creation*.
 - **Editor** support:
   - A single bookmark can be edited before adding. The editor can be set using the environment variable *EDITOR* or by explicitly specifying the editor. The latter takes preference. If -a is used along with -w, the details are populated in the editor template.

--- a/buku.1
+++ b/buku.1
@@ -73,7 +73,7 @@ Bookmarks with immutable titles are listed with '(L)' after the title.
 .PP
 .IP 9. 4
 \fBImport\fR:
-  - URLs starting with `place:`, `file://` and `apt://` are ignored during import.
+  - URLs starting with `place:`, `file://` and `apt:` are ignored during import.
 .PP
 .IP 10. 4
 \fBEncryption\fR is optional and manual. AES256 algorithm is used. To use encryption, the database file should be unlocked (-k) before using \fBbuku\fR and locked (-l) afterwards. Between these 2 operations, the database file lies unencrypted on the disk, and NOT in memory. Also, note that the database file is \fBunencrypted on creation\fR.

--- a/buku.py
+++ b/buku.py
@@ -1897,7 +1897,7 @@ def is_bad_url(url):
 def is_nongeneric_url(url):
     '''Returns true for URLs which are non-http and non-generic'''
 
-    ignored_prefix = ['place:', 'file://', 'apt://']
+    ignored_prefix = ['place:', 'file://', 'apt:']
 
     for prefix in ignored_prefix:
         if url.startswith(prefix):

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -472,7 +472,8 @@ def test_network_handler_with_url(url, exp_res):
     'url, exp_res',
     [
         ('http://example.com', False),
-        ('apt:package1,package2,package3', True),
+        ('apt:package1,package2,package3', False),
+        ('apt://firefox', True)
         ('file:///tmp/vim-markdown-preview.html', True),
     ]
 )

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -475,6 +475,7 @@ def test_network_handler_with_url(url, exp_res):
         ('apt:package1,package2,package3', True),
         ('apt://firefox', True),
         ('file:///tmp/vim-markdown-preview.html', True),
+        ('place:sort=8&maxResults=10', True),
     ]
 )
 def test_is_nongeneric_url(url, exp_res):

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -471,9 +471,9 @@ def test_network_handler_with_url(url, exp_res):
 @pytest.mark.parametrize(
     'url, exp_res',
     [
-        ('http://example.com', False)
-        ('apt:package1,package2,package3', True)
-        ('file:///tmp/vim-markdown-preview.html', True)
+        ('http://example.com', False),
+        ('apt:package1,package2,package3', True),
+        ('file:///tmp/vim-markdown-preview.html', True),
     ]
 )
 def test_is_nongeneric_url(url, exp_res):

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -472,7 +472,7 @@ def test_network_handler_with_url(url, exp_res):
     'url, exp_res',
     [
         ('http://example.com', False),
-        ('apt:package1,package2,package3', False),
+        ('apt:package1,package2,package3', True),
         ('apt://firefox', True),
         ('file:///tmp/vim-markdown-preview.html', True),
     ]

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -466,3 +466,17 @@ def test_network_handler_with_url(url, exp_res):
     buku.myproxy = None
     res = buku.network_handler(url)
     assert res == exp_res
+
+
+@pytest.mark.parametrize(
+    'url, exp_res',
+    [
+        ('http://example.com', False)
+        ('apt:package1,package2,package3', True)
+        ('file:///tmp/vim-markdown-preview.html', True)
+    ]
+)
+def test_is_nongeneric_url(url, exp_res):
+    import buku
+    res = buku.is_nongeneric_url(url)
+    assert res == exp_res

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -473,7 +473,7 @@ def test_network_handler_with_url(url, exp_res):
     [
         ('http://example.com', False),
         ('apt:package1,package2,package3', False),
-        ('apt://firefox', True)
+        ('apt://firefox', True),
         ('file:///tmp/vim-markdown-preview.html', True),
     ]
 )


### PR DESCRIPTION
test non generic url check method.

not quite sure if apturl is correct, as it may also not contain double slash 

reference https://wiki.ubuntu.com/AptUrl

also need example for `place:` prefix url

e: fyi: startswith can accept list of string https://stackoverflow.com/a/20461857/1766261