### PR TITLE
Feature/search multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   - [Installing with a package manager](#installing-with-a-package-manager)
   - [Installing from this repository](#installing-from-this-repository)
     - [Running as a standalone utility](#running-as-a-standalone-utility)
-    - [Attached packages](#attached-packages)
+    - [Release packages](#release-packages)
 - [Shell completion](#shell-completion)
 - [Usage](#usage)
   - [Cmdline options](#cmdline-options)
@@ -127,7 +127,7 @@ To remove, run:
     $ chmod +x buku.py
     $ ./buku.py
 
-##### Attached packages
+##### Release packages
 
 Packages for Arch Linux, CentOS, Fedora and Ubuntu are available with the [latest stable release](https://github.com/jarun/Buku/releases/latest).
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ PROMPT KEYS:
   - --sall : match all the keywords in URL, title or tags.
   - --deep : match **substrings** (`match` matches `rematched`) in URL, title and tags.
   - --sreg : match a regular expression (ignores --deep).
-  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the '-' character must be space separated: ` - ` instead of `-`. This is to distinguish it from hyphenated tags (e.g., `some-tag-name`).
+  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the ` - ` operator and the ` + ` delimiter must be space separated: ` - ` instead of `-` and ` + ` instead of `+`. This is to distinguish them from hyphenated tags (e.g., `some-tag-name`) and tags with '+'s (e.g., `some+tag+name`).
   - Search results are indexed serially. This index is different from actual database index of a bookmark record which is shown within `[]` after the title.
 - **Import**:
   - URLs starting with `place:`, `file://` and `apt:` are ignored during import.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ SEARCH OPTIONS:
                            search bookmarks by tags
                            use ',' to find entries matching ANY tag
                            use '+' to find entries matching ALL tags
-                           excludes entries matching tags following '-'
+                           excludes entries matching tags following ' - '
                            list all tags, if no search keywords
 ENCRYPTION OPTIONS:
       -l, --lock [N]       encrypt DB file with N (> 0, default 8)
@@ -244,7 +244,7 @@ PROMPT KEYS:
     S keyword [...]        search for records with ALL keywords
     d                      match substrings ('pen' matches 'opened')
     r expression           run a regex search
-    t [...]                search bookmarks by a tag or show taglist
+    t [...]                search bookmarks by tags or show taglist
                            list index after a tag listing shows records with the tag
     o id|range [...]       browse bookmarks by indices and/or ranges
     p id|range [...]       print bookmarks by indices and/or ranges
@@ -286,7 +286,7 @@ PROMPT KEYS:
   - --sall : match all the keywords in URL, title or tags.
   - --deep : match **substrings** (`match` matches `rematched`) in URL, title and tags.
   - --sreg : match a regular expression (ignores --deep).
-  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. (Note: these cannot be combined). Exclude bookmarks matching certain tags from the results by using `+` followed by the tags. 
+  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the '-' character must be space separated: ` - ` instead of `-`. This is to distinguish it from hyphenated tags (e.g., `some-tag-name`).
   - Search results are indexed serially. This index is different from actual database index of a bookmark record which is shown within `[]` after the title.
 - **Import**:
   - URLs starting with `place:`, `file://` and `apt:` are ignored during import.
@@ -506,7 +506,7 @@ for resp, url in zip(gr_results, urls):
 20. **Search** for bookmarks matching **ALL** of the tags `kernel`, `debugging`, `general kernel concepts`:
 
         $ buku --stag kernel + debugging + general kernel concepts
-21. **Search** for bookmarks matching both the tags `kernel` and `debugging`, but excluding bookmarks matching the tag `general kernel concepts`:
+21. **Search** for bookmarks matching both the tags `kernel` and `debugging`, but **excluding** bookmarks matching the tag `general kernel concepts`:
 
         $ buku --stag kernel + debugging - general kernel concepts
 22. List **all unique tags** alphabetically:

--- a/buku.1
+++ b/buku.1
@@ -69,7 +69,7 @@ Bookmarks with immutable titles are listed with '(L)' after the title.
   - --sall : match all the keywords in URL, title or tags.
   - --deep : match \fBsubstrings\fR (`match` matches `rematched`) in URL, title and tags.
   - --sreg : match a regular expression (ignores --deep).
-  - --stag : search bookmarks by a tag, or list all tags alphabetically with usage count (if no arguments).
+  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the '-' character must be space separated: ` - ` instead of `-`. This is to distinguish it from hyphenated tags (e.g., `some-tag-name`).
   - Search results are indexed serially. This index is different from actual database index of a bookmark record which is shown within '[]' after the title.
 .PP
 .IP 9. 4
@@ -154,8 +154,18 @@ Search modifier to match substrings. Works with --sany, --sall.
 .BI \-r " " \--sreg " expression"
 Scan for a regular expression match.
 .TP
-.BI \-t " " \--stag " [...]"
-Search bookmarks by a tag. List all tags alphabetically, if no arguments. The usage count (number of bookmarks having the tag) is shown within first brackets.
+.BI \-t " " \--stag " [tag [,|+] ...] [\- tag, ...]"
+Search bookmarks by tags.
+.br
+Use ',' delimiter to find entries matching ANY of the tags
+.br
+Use '+' delimiter to find entries matching ALL of the tags
+.br
+NOTE: Cannot combine ',' and '+' in the same search
+.br
+Use ' - ' to exclude bookmarks that match the tags that follow. (Note that the '-' character must be space separated).
+.br
+List all tags alphabetically, if no arguments. The usage count (number of bookmarks having the tag) is shown within first brackets.
 .SH ENCRYPTION OPTIONS
 .TP
 .BI \-l " " \--lock " [N]"
@@ -506,6 +516,28 @@ The last index is moved to the deleted index to keep the DB compact.
 .EE
 .PP
 .IP 19. 4
+\fBSearch\fR for bookmarks matching \fBANY\fR of the tags 'kernel', 'debugging', 'general kernel concepts':
+.PP
+.EX
+.IP
+.B buku --stag kernel, debugging, general kernel concepts
+.EE
+.PP
+.IP 20.4
+\fBSearch\fR for bookmarks matching \fBALL\fR of the tags 'kernel', 'debugging', 'general kernel concepts':
+.PP
+.EX
+.IP
+.B buku --stag kernel + debugging + general kernel concepts
+.EE
+.PP
+.IP 21.4
+\fBSearch\fR for bookmarks matching both the tags `kernel` and `debugging`, but \fBexcluding\fR bookmarks matching the tag 'general kernel concepts':
+.PP
+.EX
+.IP
+.B buku --stag kernel + debugging - general kernel concepts
+.IP 22.4
 List \fBall unique tags\fR alphabetically:
 .PP
 .EX
@@ -513,7 +545,7 @@ List \fBall unique tags\fR alphabetically:
 .B buku --stag
 .EE
 .PP
-.IP 20. 4
+.IP 23. 4
 Run a \fBsearch and update\fR the results:
 .PP
 .EX
@@ -521,7 +553,7 @@ Run a \fBsearch and update\fR the results:
 .B buku -s kernel debugging -u --tag + linux kernel
 .EE
 .PP
-.IP 21. 4
+.IP 24. 4
 Run a \fBsearch and delete\fR the results:
 .PP
 .EX
@@ -529,7 +561,7 @@ Run a \fBsearch and delete\fR the results:
 .B buku -s kernel debugging -d
 .EE
 .PP
-.IP 22. 4
+.IP 25. 4
 \fBEncrypt or decrypt\fR DB with \fBcustom number of iterations\fR (15) to generate key:
 .PP
 .EX
@@ -542,7 +574,7 @@ Run a \fBsearch and delete\fR the results:
 .IP "" 4
 The same number of iterations must be specified for one lock & unlock instance. Default is 8, if omitted.
 .PP
-.IP 23. 4
+.IP 26. 4
 \fBShow details\fR of bookmarks at index 15012014 and ranges 20-30, 40-50:
 .PP
 .EX
@@ -550,7 +582,7 @@ The same number of iterations must be specified for one lock & unlock instance. 
 .B buku -p 20-30 15012014 40-50
 .EE
 .PP
-.IP 24. 4
+.IP 27. 4
 Show details of the \fBlast 10 bookmarks\fR:
 .PP
 .EX
@@ -558,7 +590,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku -p -10
 .EE
 .PP
-.IP 25. 4
+.IP 28. 4
 \fBShow all\fR bookmarks with real index from database:
 .PP
 .EX
@@ -567,7 +599,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku -p | more
 .EE
 .PP
-.IP 26. 4
+.IP 29. 4
 \fBReplace tag\fR 'old tag' with 'new tag':
 .PP
 .EX
@@ -575,7 +607,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku --replace 'old tag' 'new tag'
 .EE
 .PP
-.IP 27. 4
+.IP 30. 4
 \fBDelete tag\fR 'old tag' from DB:
 .PP
 .EX
@@ -583,7 +615,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku --replace 'old tag'
 .EE
 .PP
-.IP 28. 4
+.IP 31. 4
 \fBAppend (or delete) tags\fR 'tag 1', 'tag 2' to (or from) existing tags of bookmark at index 15012014:
 .PP
 .EX
@@ -592,7 +624,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku -u 15012014 --tag - tag 1, tag 2
 .EE
 .PP
-.IP 29. 4
+.IP 32. 4
 \fBOpen URL\fR at index 15012014 in browser:
 .PP
 .EX
@@ -600,7 +632,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .B buku -o 15012014
 .EE
 .PP
-.IP 30. 4
+.IP 33. 4
 List bookmarks with \fBno title or tags\fR for bookkeeping:
 .PP
 .EX
@@ -608,7 +640,7 @@ List bookmarks with \fBno title or tags\fR for bookkeeping:
 .B buku -S blank
 .EE
 .PP
-.IP 31. 4
+.IP 34. 4
 List bookmarks with \fBimmutable title\fR:
 .PP
 .EX
@@ -616,7 +648,7 @@ List bookmarks with \fBimmutable title\fR:
 .B buku -S immutable
 .EE
 .PP
-.IP 32. 4
+.IP 35. 4
 \fBShorten\fR the URL www.google.com and the URL at index 20:
 .PP
 .EX
@@ -625,7 +657,7 @@ List bookmarks with \fBimmutable title\fR:
 .B buku --shorten 20
 .EE
 .PP
-.IP 33. 4
+.IP 36. 4
 \fBAppend, remove tags at prompt\fR (taglist index to the left, bookmark index to the right):
 .PP
 .EX

--- a/buku.1
+++ b/buku.1
@@ -69,7 +69,7 @@ Bookmarks with immutable titles are listed with '(L)' after the title.
   - --sall : match all the keywords in URL, title or tags.
   - --deep : match \fBsubstrings\fR (`match` matches `rematched`) in URL, title and tags.
   - --sreg : match a regular expression (ignores --deep).
-  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the '-' character must be space separated: ` - ` instead of `-`. This is to distinguish it from hyphenated tags (e.g., `some-tag-name`).
+  - --stag : search bookmarks by tags, or list all tags alphabetically with usage count (if no arguments). Delimit the list of tags in the query with `,` to search for bookmarks that match ANY of the listed tags. Delimit tags with `+` to search for bookmarks that match ALL of the listed tags. Note that `,` and `+` cannot be used together in the same search. Exclude bookmarks matching certain tags from the results by using ` - ` followed by the tags. Note that the ` - ` operator and the ` + ` delimiter must be space separated: ` - ` instead of `-` and ` + ` instead of `+`. This is to distinguish them from hyphenated tags (e.g., `some-tag-name`) and tags with '+'s (e.g., `some+tag+name`).
   - Search results are indexed serially. This index is different from actual database index of a bookmark record which is shown within '[]' after the title.
 .PP
 .IP 9. 4
@@ -159,11 +159,11 @@ Search bookmarks by tags.
 .br
 Use ',' delimiter to find entries matching ANY of the tags
 .br
-Use '+' delimiter to find entries matching ALL of the tags
+Use ' + ' delimiter to find entries matching ALL of the tags. (Note that the ' + ' delimiter must be space separated)
 .br
 NOTE: Cannot combine ',' and '+' in the same search
 .br
-Use ' - ' to exclude bookmarks that match the tags that follow. (Note that the '-' character must be space separated).
+Use ' - ' to exclude bookmarks that match the tags that follow. (Note that the '-' operator must be space separated).
 .br
 List all tags alphabetically, if no arguments. The usage count (number of bookmarks having the tag) is shown within first brackets.
 .SH ENCRYPTION OPTIONS

--- a/buku.py
+++ b/buku.py
@@ -1087,7 +1087,7 @@ class BukuDb:
         '''
 
         # do not allow combination of search logics
-        if '+' in tags and ',' in tags:
+        if ' + ' in tags and ',' in tags:
             logerr("Cannot use both '+' and ',' in same search")
             return
 
@@ -1099,9 +1099,9 @@ class BukuDb:
 
         search_operator = 'OR'
         tag_delim = ','
-        if '+' in tags:
+        if ' + ' in tags:
             search_operator = 'AND'
-            tag_delim = '+'
+            tag_delim = ' + '
 
         tags = [delim_wrap(t.strip()) for t in tags.split(tag_delim)]
 

--- a/buku.py
+++ b/buku.py
@@ -1091,19 +1091,7 @@ class BukuDb:
             logerr("Cannot use both '+' and ',' in same search")
             return
 
-        excluded_tags = None
-        if ' - ' in tags:
-            tags, excluded_tags = tags.split(' - ', 1)
-            # join with pipe to construct regex
-            excluded_tags = '|'.join([delim_wrap(t.strip()) for t in excluded_tags.split(',')])
-
-        search_operator = 'OR'
-        tag_delim = ','
-        if ' + ' in tags:
-            search_operator = 'AND'
-            tag_delim = ' + '
-
-        tags = [delim_wrap(t.strip()) for t in tags.split(tag_delim)]
+        tags, search_operator, excluded_tags = prep_tag_search(tags)
 
         query = "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
         for tag in tags[1:]:
@@ -2350,6 +2338,37 @@ def parse_tags(keywords=[]):
 
     # Wrap with delimiter
     return delim_wrap(DELIM.join(sorted_tags))
+
+
+def prep_tag_search(tags):
+    """Prepare list of tags to search and determine search operator
+
+    :param tags: list of tags to search as string
+    :return: tuple (
+                    list of formatted tags to search,
+                    a string indicating query search operator (either OR or AND),
+                    a regex string of tags (used to exclude matching bookmarks),
+                   ),
+             None, if ' - ' operator is not in the tags argument
+    """
+
+    excluded_tags = None
+    if ' - ' in tags:
+        tags, excluded_tags = tags.split(' - ', 1)
+
+        excluded_taglist = [delim_wrap(t.strip()) for t in excluded_tags.split(',')]
+        # join with pipe to construct regex string
+        excluded_tags = '|'.join(excluded_taglist)
+
+    search_operator = 'OR'
+    tag_delim = ','
+    if ' + ' in tags:
+        search_operator = 'AND'
+        tag_delim = ' + '
+
+    tags = [delim_wrap(t.strip()) for t in tags.split(tag_delim)]
+
+    return tags, search_operator, excluded_tags
 
 
 def edit_at_prompt(obj, nav):

--- a/buku.py
+++ b/buku.py
@@ -1088,7 +1088,7 @@ class BukuDb:
 
         # do not allow combination of search logics
         if '+' in tags and ',' in tags:
-            print('Cannot use both "+" and "," in same search')
+            logerr("Cannot use both '+' and ',' in same search")
             return
 
         excluded_tags = None
@@ -2068,7 +2068,7 @@ PROMPT KEYS:
     S keyword [...]        search for records with ALL keywords
     d                      match substrings ('pen' matches 'opened')
     r expression           run a regex search
-    t [...]                search bookmarks by tags or show tag list
+    t [...]                search bookmarks by tags or show taglist
                            list index after a tag listing shows records with the tag
     o id|range [...]       browse bookmarks by indices and/or ranges
     p id|range [...]       print bookmarks by indices and/or ranges
@@ -3131,7 +3131,7 @@ POSITIONAL ARGUMENTS:
                          search bookmarks by tags
                          use ',' to find entries matching ANY tag
                          use '+' to find entries matching ALL tags
-                         excludes entries matching tags following '-'
+                         excludes entries matching tags following ' - '
                          list all tags, if no search keywords''')
     addarg = search_grp.add_argument
     addarg('-s', '--sany', action='store_true', help=HIDE)

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -107,29 +107,28 @@ def test_parse_tags(keywords, exp_res):
     assert res == exp_res
 
 
-def test_prep_tag_search():
+@pytest.mark.parametrize(
+    'taglist, exp_res',
+    [
+        [
+            'tag1, tag2+3',
+            ([',tag1,', ',tag2+3,'], 'OR', None)
+        ],
+        [
+            'tag1 + tag2-3 + tag4',
+            ([',tag1,', ',tag2-3,', ',tag4,'], 'AND', None)
+        ],
+        [
+            'tag1, tag2-3 - tag4, tag5',
+            ([',tag1,', ',tag2-3,'], 'OR', ',tag4,|,tag5,')
+        ]
+    ]
+)
+def test_prep_tag_search(taglist, exp_res):
     """test prep_tag_search helper function"""
 
-    taglist1 = 'tag1, tag2+3'
-    results = prep_tag_search(taglist1)
-    expected = ([',tag1,', ',tag2+3,'],
-                'OR',
-                None)
-    assert results == expected
-
-    taglist2 = 'tag1 + tag2-3 + tag4'
-    results = prep_tag_search(taglist2)
-    expected = ([',tag1,', ',tag2-3,', ',tag4,'],
-                'AND',
-                None)
-    assert results == expected
-
-    taglist3 = 'tag1, tag2-3 - tag4, tag5'
-    results = prep_tag_search(taglist3)
-    expected = ([',tag1,', ',tag2-3,'],
-                'OR',
-                ',tag4,|,tag5,')
-    assert results == expected
+    results = prep_tag_search(taglist)
+    assert results == exp_res
 
 
 @pytest.mark.parametrize(

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -8,7 +8,7 @@ import unittest
 
 import pytest
 
-from buku import is_int, parse_tags
+from buku import is_int, parse_tags, prep_tag_search
 
 only_python_3_5 = pytest.mark.skipif(
     sys.version_info < (3, 5), reason="requires Python 3.5 or later")
@@ -105,6 +105,31 @@ def test_parse_tags(keywords, exp_res):
         exp_res = buku.DELIM
     res = buku.parse_tags(keywords)
     assert res == exp_res
+
+
+def test_prep_tag_search():
+    """test prep_tag_search helper function"""
+
+    taglist1 = 'tag1, tag2+3'
+    results = prep_tag_search(taglist1)
+    expected = ([',tag1,', ',tag2+3,'],
+                'OR',
+                None)
+    assert results == expected
+
+    taglist2 = 'tag1 + tag2-3 + tag4'
+    results = prep_tag_search(taglist2)
+    expected = ([',tag1,', ',tag2-3,', ',tag4,'],
+                'AND',
+                None)
+    assert results == expected
+
+    taglist3 = 'tag1, tag2-3 - tag4, tag5'
+    results = prep_tag_search(taglist3)
+    expected = ([',tag1,', ',tag2-3,'],
+                'OR',
+                ',tag4,|,tag5,')
+    assert results == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -273,7 +273,6 @@ class TestBukuDb(unittest.TestCase):
                 expected = [(i + 1,) + tuple(self.bookmarks[i])]
                 self.assertEqual(results, expected)
 
-    # @unittest.skip('skipping')
     def test_search_by_multiple_tags_search_any(self):
         # adding bookmarks
         for bookmark in self.bookmarks:
@@ -304,7 +303,6 @@ class TestBukuDb(unittest.TestCase):
             ]
             self.assertEqual(results, expected)
 
-    # @unittest.skip('skipping')
     def test_search_by_multiple_tags_search_all(self):
         # adding bookmarks
         for bookmark in self.bookmarks:
@@ -329,7 +327,6 @@ class TestBukuDb(unittest.TestCase):
             ]
             self.assertEqual(results, expected)
 
-    # @unittest.skip('skipping')
     def test_search_by_tags_enforces_space_seprations_search_all(self):
 
         bookmark1 = ['https://bookmark1.com',
@@ -369,7 +366,6 @@ class TestBukuDb(unittest.TestCase):
             ]
             self.assertEqual(results, expected)
 
-    # @unittest.skip('skipping')
     def test_search_by_tags_exclusion(self):
         # adding bookmarks
         for bookmark in self.bookmarks:
@@ -398,7 +394,6 @@ class TestBukuDb(unittest.TestCase):
             ]
             self.assertEqual(results, expected)
 
-    # @unittest.skip('skipping')
     def test_search_by_tags_enforces_space_seprations_exclusion(self):
 
         bookmark1 = ['https://bookmark1.com',
@@ -594,7 +589,6 @@ class TestBukuDb(unittest.TestCase):
 
     # def test_import_bookmark(self):
         # self.fail()
-
 
 @given(
     index=st.integers(min_value=-10, max_value=10),
@@ -987,6 +981,45 @@ def test_update_rec_exec_arg(caplog, kwargs, exp_query, exp_arguments):
     bdb = BukuDb()
     res = bdb.update_rec(**kwargs)
     assert res
+    exp_log = 'query: "{}", args: {}'.format(exp_query, exp_arguments)
+    assert caplog.records[-1].getMessage() == exp_log
+    assert caplog.records[-1].levelname == 'DEBUG'
+
+
+@pytest.mark.parametrize(
+    'tags_to_search, exp_query, exp_arguments',
+    [
+        [
+            'tag1, tag2',
+            "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
+            "OR tags LIKE '%' || ? || '%' ORDER BY id ASC",
+            [',tag1,', ',tag2,']
+
+        ],
+        [
+            'tag1+tag2,tag3, tag4',
+            "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
+            "OR tags LIKE '%' || ? || '%' OR tags LIKE '%' || ? || '%' ORDER BY id ASC",
+            [',tag1+tag2,', ',tag3,', ',tag4,']
+        ],
+        [
+            'tag1 + tag2+tag3',
+            "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
+            "AND tags LIKE '%' || ? || '%' ORDER BY id ASC",
+            [',tag1,', ',tag2+tag3,']
+        ],
+        [
+            'tag1-tag2 + tag 3 - tag4',
+            "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE (tags LIKE '%' || ? || '%' "
+            "AND tags LIKE '%' || ? || '%' ) AND tags NOT REGEXP ? ORDER BY id ASC",
+            [',tag1-tag2,', ',tag 3,', ',tag4,']
+        ]
+    ]
+)
+def test_search_by_tag_query(caplog, tags_to_search, exp_query, exp_arguments):
+    """test that the correct query and argments are constructed"""
+    bdb = BukuDb()
+    bdb.search_by_tag(tags_to_search)
     exp_log = 'query: "{}", args: {}'.format(exp_query, exp_arguments)
     assert caplog.records[-1].getMessage() == exp_log
     assert caplog.records[-1].levelname == 'DEBUG'

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -330,6 +330,46 @@ class TestBukuDb(unittest.TestCase):
             self.assertEqual(results, expected)
 
     # @unittest.skip('skipping')
+    def test_search_by_tags_enforces_space_seprations_search_all(self):
+
+        bookmark1 = ['https://bookmark1.com',
+                     'Bookmark One',
+                     parse_tags(['tag, two,tag+two']),
+                     "test case for bookmark with '+' in tag"]
+
+        bookmark2 = ['https://bookmark2.com',
+                     'Bookmark Two',
+                     parse_tags(['tag,two, tag-two']),
+                     "test case for bookmark with hyphenated tag"]
+
+        self.bdb.add_rec(*bookmark1)
+        self.bdb.add_rec(*bookmark2)
+
+        with mock.patch('buku.prompt'):
+            # check that space separation for ' + ' operator is enforced
+            results = self.bdb.search_by_tag('tag+two')
+            # Expect a list of five-element tuples containing all bookmark data
+            # db index, URL, title, tags, description
+            expected = [
+                (1, 'https://bookmark1.com', 'Bookmark One',
+                 parse_tags([',tag,two,tag+two,']),
+                 "test case for bookmark with '+' in tag")
+            ]
+            self.assertEqual(results, expected)
+            results = self.bdb.search_by_tag('tag + two')
+            # Expect a list of five-element tuples containing all bookmark data
+            # db index, URL, title, tags, description
+            expected = [
+                (1, 'https://bookmark1.com', 'Bookmark One',
+                 parse_tags([',tag,two,tag+two,']),
+                 "test case for bookmark with '+' in tag"),
+                (2, 'https://bookmark2.com', 'Bookmark Two',
+                 parse_tags([',tag,two,tag-two,']),
+                 "test case for bookmark with hyphenated tag"),
+            ]
+            self.assertEqual(results, expected)
+
+    # @unittest.skip('skipping')
     def test_search_by_tags_exclusion(self):
         # adding bookmarks
         for bookmark in self.bookmarks:
@@ -355,6 +395,49 @@ class TestBukuDb(unittest.TestCase):
                 (4, 'https://newbookmark.com', 'New Bookmark',
                  parse_tags([',test,old,new,']),
                  'additional bookmark to test multiple tag search')
+            ]
+            self.assertEqual(results, expected)
+
+    # @unittest.skip('skipping')
+    def test_search_by_tags_enforces_space_seprations_exclusion(self):
+
+        bookmark1 = ['https://bookmark1.com',
+                     'Bookmark One',
+                     parse_tags(['tag, two,tag+two']),
+                     "test case for bookmark with '+' in tag"]
+
+        bookmark2 = ['https://bookmark2.com',
+                     'Bookmark Two',
+                     parse_tags(['tag,two, tag-two']),
+                    "test case for bookmark with hyphenated tag"]
+
+        bookmark3 = ['https://bookmark3.com',
+                     'Bookmark Three',
+                     parse_tags(['tag, tag three']),
+                    "second test case for bookmark with hyphenated tag"]
+
+        self.bdb.add_rec(*bookmark1)
+        self.bdb.add_rec(*bookmark2)
+        self.bdb.add_rec(*bookmark3)
+
+        with mock.patch('buku.prompt'):
+            # check that space separation for ' - ' operator is enforced
+            results = self.bdb.search_by_tag('tag-two')
+            # Expect a list of five-element tuples containing all bookmark data
+            # db index, URL, title, tags, description
+            expected = [
+                (2, 'https://bookmark2.com', 'Bookmark Two',
+                 parse_tags([',tag,two,tag-two,']),
+                 "test case for bookmark with hyphenated tag"),
+            ]
+            self.assertEqual(results, expected)
+            results = self.bdb.search_by_tag('tag - two')
+            # Expect a list of five-element tuples containing all bookmark data
+            # db index, URL, title, tags, description
+            expected = [
+                (3, 'https://bookmark3.com', 'Bookmark Three',
+                 parse_tags([',tag,tag three,']),
+                 "second test case for bookmark with hyphenated tag"),
             ]
             self.assertEqual(results, expected)
 

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -409,12 +409,12 @@ class TestBukuDb(unittest.TestCase):
         bookmark2 = ['https://bookmark2.com',
                      'Bookmark Two',
                      parse_tags(['tag,two, tag-two']),
-                    "test case for bookmark with hyphenated tag"]
+                     "test case for bookmark with hyphenated tag"]
 
         bookmark3 = ['https://bookmark3.com',
                      'Bookmark Three',
                      parse_tags(['tag, tag three']),
-                    "second test case for bookmark with hyphenated tag"]
+                     "second test case for bookmark with hyphenated tag"]
 
         self.bdb.add_rec(*bookmark1)
         self.bdb.add_rec(*bookmark2)


### PR DESCRIPTION
This PR implements the "Search multiple tags, exclusion in tag search" feature, referenced in #186.

It adds support for finding bookmarks that match 

1) ANY tag in a set of tags: `buku --stag tag1, tag2, ... tagn`
2) ALL tags in a set of tags: `buku --stag tag1 + tag2 + tag3 ... + tagn`

It also adds support for excluding bookmarks that match certain tags:

`buku --stag tag2, tag3 - tag1`

will return bookmarks that match either tag2 or tag3, but will exclude from the results bookmarks that match tag1.

I've added test cases to `tests/test_bukuDb.py` for each of the three scenarios above.

#### Program help

I've updated the following sections of the README: Cmndline options, Operational notes, examples (19-21).

I've updated the man page's program options. I may have done the notation/syntax describing the the options wrong, so please let me know and I'll amend!

Please let me know if anything should change. Thanks!
