### PR TITLE
Fix incorrect docsting in prep_tag_search

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2347,9 +2347,8 @@ def prep_tag_search(tags):
     :return: tuple (
                     list of formatted tags to search,
                     a string indicating query search operator (either OR or AND),
-                    a regex string of tags (used to exclude matching bookmarks),
-                   ),
-             None, if ' - ' operator is not in the tags argument
+                    a regex string of tags (None if ' - ' operator not in tags)
+                   )
     """
 
     excluded_tags = None


### PR DESCRIPTION
This fixes an incorrect docstring description of the return value of `prep_tag_search`. Previous version stated incorrectly that the return value of `prep_tag_search` was None if ` - ` was not present in the `tags` argument. But it's actually only the third element in the returned tuple that would be None in that case.