### PR TITLE
Add notes on support for bookmarks.html as discussed in issue #174

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 `buku` fetches the title of a bookmarked web page and stores it along with any additional comments and tags. You can use your favourite editor to compose and update bookmarks. With multiple search options, including regex and a deep scan mode (particularly for URLs), it can find any bookmark instantly. Multiple search results can be opened in the browser at once.
 
-For GUI integration, refer to the wiki page on [System integration](https://github.com/jarun/Buku/wiki/System-integration). If you prefer the terminal, thanks to the [shell completion](#shell-completion) scripts, you don't need to memorize any of the options. There's an Easter egg to revisit random forgotten bookmarks too.
+For GUI integration (or to sync bookmarks with your favourite bookmark management service), refer to the wiki page on [System integration](https://github.com/jarun/Buku/wiki/System-integration). If you prefer the terminal, thanks to the [shell completion](#shell-completion) scripts, you don't need to memorize any of the options. There's an Easter egg to revisit random forgotten bookmarks too.
 
 We have one of the best documentation around. You can start with the [Examples](#examples). *Buku* is too busy to track you - no history, obsolete records, usage analytics or homing. To learn more on how it works or to contribute to the project, please refer to the wiki page on [Operational notes](https://github.com/jarun/Buku/wiki/Operational-notes).
 

--- a/buku.1
+++ b/buku.1
@@ -74,7 +74,8 @@ Bookmarks with immutable titles are listed with '(L)' after the title.
 .PP
 .IP 9. 4
 \fBImport\fR:
-  - Auto-import looks in the default installation path and default user profile.
+  - Buku supports bookmarks.html, the standard format used by most browsers and bookmarking services for importing/exporting bookmarks. bookmarks.html files can be imported into Buku with the -i import option (`buku -i path/to/bookmarks.html`).
+  - Auto-import (-ai) looks in the default installation path and default user profile to directly import bookmarks from Firefox and Google Chrome.
   - URLs starting with `place:`, `file://` and `apt:` are ignored during import.
   - Folder names are automatically imported as tags if --tacit is used.
 .PP


### PR DESCRIPTION
This adds the notes on bookmarks.html support, as discussed in #174.

- User is referred to System Integration wiki for information on syncing bookmarks with bookmarking services.
- A line about bookmarks.html support is added to the **Import** section of the Operational Notes wiki.
- Small changes to the Auto-import line in the same section, to distinguish between the two options.

