### PR TITLE
Add breaks between lines in man page examples

### DIFF
--- a/buku.1
+++ b/buku.1
@@ -344,6 +344,7 @@ can be integrated in a GUI environment with simple tweaks. Refer to:
 .EX
 .IP
 .B buku -w
+.br
 .B buku -w 'macvim -f' -a https://ddg.gg search engine, privacy
 .EE
 .PP
@@ -424,6 +425,7 @@ Applies to --url, --title and --tag too.
 .EX
 .IP
 .B buku -e bookmarks.html --tag tag 1, tag 2
+.br
 .B buku -e bookmarks.md --tag tag 1, tag 2
 .EE
 .PP
@@ -436,6 +438,7 @@ All bookmarks are exported if --tag is not specified.
 .EX
 .IP
 .B buku -i bookmarks.html
+.br
 .B buku -i bookmarks.md
 .EE
 .PP
@@ -456,6 +459,7 @@ Applies to --title and --tag too. URL cannot be deleted without deleting the boo
 .EX
 .IP
 .B buku -u
+.br
 .B buku -u --tacit (show only failures and exceptions)
 .EE
 .PP
@@ -487,6 +491,7 @@ The last index is moved to the deleted index to keep the DB compact.
 .EX
 .IP
 .B buku -d 100-200
+.br
 .B buku -d 100 15 200
 .EE
 .PP
@@ -496,6 +501,7 @@ The last index is moved to the deleted index to keep the DB compact.
 .EX
 .IP
 .B buku kernel debugging
+.br
 .B buku -s kernel debugging
 .EE
 .PP
@@ -596,6 +602,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .EX
 .IP
 .B buku -p
+.br
 .B buku -p | more
 .EE
 .PP
@@ -621,6 +628,7 @@ Show details of the \fBlast 10 bookmarks\fR:
 .EX
 .IP
 .B buku -u 15012014 --tag + tag 1, tag 2
+.br
 .B buku -u 15012014 --tag - tag 1, tag 2
 .EE
 .PP
@@ -654,6 +662,7 @@ List bookmarks with \fBimmutable title\fR:
 .EX
 .IP
 .B buku --shorten www.google.com
+.br
 .B buku --shorten 20
 .EE
 .PP
@@ -663,12 +672,19 @@ List bookmarks with \fBimmutable title\fR:
 .EX
 .IP
 // append tags at taglist indices 4 and 6-9 to existing tags in bookmarks at indices 5 and 2-3
+.br
 .B buku (? for help) g 4 9-6 >> 5 3-2
+.br
 // set tags at taglist indices 4 and 6-9 as tags in bookmarks at indices 5 and 2-3
+.br
 .B buku (? for help) g 4 9-6 > 5 3-2
+.br
 // remove all tags from bookmarks at indices 5 and 2-3
+.br
 .B buku (? for help) g > 5 3-2
+.br
 // remove tags at taglist indices 4 and 6-9 from tags in bookmarks at indices 5 and 2-3
+.br
 .B buku (? for help) g 4 9-6 << 5 3-2
 .EE
 .SH AUTHOR


### PR DESCRIPTION
In the `EXAMPLES` section of the man page, there are several example subsections where two example cases are listed back to back. E.g.:
```
buku -w
buku -w 'macvim -f' -a https://ddg.gg search engine, privacy
```
However `.br` breaks are missing from these cases, and the examples display on a single line:
`buku -w buku -w 'macvim -f' -a https://ddg.gg search engine, privacy` 

This PR adds `.br` breaks to make new lines to separate these cases.