### PR TITLE
Remove recommonmark from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ urllib3>=1.13.1
 beautifulsoup4>=4.4.1
 cryptography>=1.2.3
 requests>=2.9.1
-recommonmark>=0.4.0


### PR DESCRIPTION
Removes unnecessary addition of `recommonmark` dependency to `requirements.txt`