### PR TITLE
Update RTD index with proper package summary

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 Buku
 ====
 
-A highly delicious bookmark manager. Your mini web!
+Powerful command-line bookmark manager. Your mini web!
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Keeps RTD documentation up to date with the current package summary.

BTW, the RTD `latest` branch is still accessible. Did you decide to keep it or should it be set to private? (It might also be able to be set to 'inactive').