### PR TITLE
Get default profile path from profiles.ini file

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2567,9 +2567,10 @@ def get_firefox_profile_name(path):
     """
     from configparser import ConfigParser
 
-    if os.path.exists(path) and os.path.isfile(path):
+    profile_path = os.path.join(path, 'profiles.ini')
+    if os.path.exists(profile_path):
         config = ConfigParser()
-        config_data = config.read(path)
+        config_data = config.read(profile_path)
         profiles_names = [section for section in config.sections() if section.startswith('Profile')]
         if not profiles_names:
             return None
@@ -2584,7 +2585,7 @@ def get_firefox_profile_name(path):
             # There is no default profile
             return None
     else:
-        logerr("get_firefox_profile_name(): `path' is not a file")
+        logerr("get_firefox_profile_name(): `path' does not exist")
         return None
 
 

--- a/buku.py
+++ b/buku.py
@@ -2565,7 +2565,7 @@ def get_firefox_profile_name(path):
     profile : str
         Firefox profile name.
     """
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoOptionError
 
     profile_path = os.path.join(path, 'profiles.ini')
     if os.path.exists(profile_path):
@@ -2580,7 +2580,7 @@ def get_firefox_profile_name(path):
                 if config.getboolean(name, 'default'):
                     profile_path = config.get(name, 'path')
                     return profile_path
-            except configparser.NoOptionError:
+            except NoOptionError:
                 continue
             # There is no default profile
             return None

--- a/buku.py
+++ b/buku.py
@@ -2088,7 +2088,7 @@ class BukuDb:
 
         roots = data['roots']
         for entry in roots:
-            # Needed to skip sync_transaction_version key from roots
+            # Needed to skip 'sync_transaction_version' key from roots
             if isinstance(roots[entry], str):
                 continue
             for item in self.traverse_bm_folder(roots[entry]['children'], unique_tag, roots[entry]['name'], add_parent_folder_as_tag):

--- a/buku.py
+++ b/buku.py
@@ -2589,7 +2589,7 @@ def get_firefox_profile_name(path):
             # There is no default profile
             return None
     else:
-        logdbg('get_firefox_profile_name(): `path\' {} does not exist'.format(path))
+        logdbg('get_firefox_profile_name(): {} does not exist'.format(path))
         return None
 
 

--- a/buku.py
+++ b/buku.py
@@ -2570,7 +2570,7 @@ def get_firefox_profile_name(path):
     profile_path = os.path.join(path, 'profiles.ini')
     if os.path.exists(profile_path):
         config = ConfigParser()
-        config_data = config.read(profile_path)
+        config.read(profile_path)
         profiles_names = [section for section in config.sections() if section.startswith('Profile')]
         if not profiles_names:
             return None

--- a/buku.py
+++ b/buku.py
@@ -2186,7 +2186,7 @@ class BukuDb:
             username = os.getlogin()
             GC_BM_DB_PATH = 'C:/Users/{}/AppData/Local/Google/Chrome/User Data/Default/Bookmarks'.format(username)
 
-            DEFAULT_FF_FOLDER = 'C:/Users/{}/AppData/Roaming/Mozilla/Firefox/Profiles'.format(username)
+            DEFAULT_FF_FOLDER = 'C:/Users/{}/AppData/Roaming/Mozilla/Firefox/'.format(username)
             profile = get_firefox_profile_name(DEFAULT_FF_FOLDER)
             if profile:
                 FF_BM_DB_PATH = os.path.join(DEFAULT_FF_FOLDER, '{}/places.sqlite'.format(profile))
@@ -2582,6 +2582,7 @@ def get_firefox_profile_name(path):
                     return profile_path
             except NoOptionError:
                 continue
+
             # There is no default profile
             return None
     else:

--- a/buku.py
+++ b/buku.py
@@ -2088,6 +2088,7 @@ class BukuDb:
 
         roots = data['roots']
         for entry in roots:
+            # Needed to skip sync_transaction_version key from roots
             if isinstance(roots[entry], str):
                 continue
             for item in self.traverse_bm_folder(roots[entry]['children'], unique_tag, roots[entry]['name'], add_parent_folder_as_tag):

--- a/buku.py
+++ b/buku.py
@@ -2589,7 +2589,7 @@ def get_firefox_profile_name(path):
             # There is no default profile
             return None
     else:
-        logerr("get_firefox_profile_name(): `path' does not exist")
+        logdbg('get_firefox_profile_name(): `path\' {} does not exist'.format(path))
         return None
 
 

--- a/buku.py
+++ b/buku.py
@@ -2088,6 +2088,8 @@ class BukuDb:
 
         roots = data['roots']
         for entry in roots:
+            if isinstance(roots[entry], str):
+                continue
             for item in self.traverse_bm_folder(roots[entry]['children'], unique_tag, roots[entry]['name'], add_parent_folder_as_tag):
                 self.add_rec(*item)
 


### PR DESCRIPTION
With this PR Firefox autoimport gets default profile from `profile.ini` file, and fix one bug in `load_chrome_database` function.

#### Debian test cases:
- [x] FF is not installed and no `.mozilla` root directory
- [x] missing `profiles.ini` file
- [x] empty `profiles.ini` file
- [x] default profile directory is missing
- [x] file places.sqlite is missing
- [x] places.sqlite is a blank file
- [x] `profiles.ini` file is a directory.

#### Ubuntu test cases:
- [x] no `.mozilla` root directory
- [x] default profile directory is missing
- [x] file places.sqlite is missing
- [x] places.sqlite is a blank file
- [x] empty `profiles.ini` file
- [x] `profiles.ini` file is a directory.

#### Mac OS test cases:
- [x] empty `profile.ini` file
- [x] `profiles.ini` file is a directory.
- [x] FF is not installed
- [x] FF installed but not started (there is no default profile)
- [x] FF installed but no bookmarks
- [x] FF installed and has some bookmarks.

#### Windows 10 test cases (@jarun):
- [x] Firefox uninstalled (no `Mozilla` root directory)
- [x] Firefox installed, `profiles.ini` missing
- [x] Firefox installed, `profiles.ini` empty
- [x] Firefox installed, default profile directory missing
- [x] Firefox installed, `places.sqlite` missing
- [x] Firefox installed, `places.sqlite` just a blank file