### PR TITLE
Search honors field filters: implements print_rec_with_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ POWER TOYS:
       -f, --format N       limit fields in -p or Json search output
                            N=1: URL, N=2: URL and tag, N=3: title,
                            N=4: URL, title and tag. To omit DB index,
-                           use 10, 20, 30, 40 instead of 1, 2, 3, 4.
+                           use N0, e.g, 10, 20, 30, 40.
       -j, --json           Json formatted output for -p and search
       --colors COLORS      set output colors in five-letter string
       --nc                 disable color output

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ POWER TOYS:
                            -n shows the last n results (like tail)
       -f, --format N       limit fields in -p or Json search output
                            N=1: URL, N=2: URL and tag, N=3: title,
-                           N=4: URL, title and tag
+                           N=4: URL, title and tag. To omit DB index,
+                           use 10, 20, 30, 40 instead of 1, 2, 3, 4.
       -j, --json           Json formatted output for -p and search
       --colors COLORS      set output colors in five-letter string
       --nc                 disable color output

--- a/buku.1
+++ b/buku.1
@@ -215,17 +215,7 @@ Show selective monochrome output with specific fields. Works with --print. Searc
 .I N
 = 4, show URL, title and tags in a single line
 .br
-.I N
-= 10, show only URL. Omits DB index.
-.br
-.I N
-= 20, show URL and tags in a single line. Omits DB index.
-.br
-.I N
-= 30, show only title. Omits DB index.
-.br
-.I N
-= 40, show URL, title and tags in a single line. Omits DB index.
+To omit DB index from printed results, use N0, e.g., 10, 20, 30, 40.
 .TP
 .BI \-j " " \--json
 Output data formatted as json, works with --print output and search results.

--- a/buku.1
+++ b/buku.1
@@ -214,6 +214,18 @@ Show selective monochrome output with specific fields. Works with --print. Searc
 .br
 .I N
 = 4, show URL, title and tags in a single line
+.br
+.I N
+= 10, show only URL. Omits DB index.
+.br
+.I N
+= 20, show URL and tags in a single line. Omits DB index.
+.br
+.I N
+= 30, show only title. Omits DB index.
+.br
+.I N
+= 40, show URL, title and tags in a single line. Omits DB index.
 .TP
 .BI \-j " " \--json
 Output data formatted as json, works with --print output and search results.

--- a/buku.py
+++ b/buku.py
@@ -3219,6 +3219,21 @@ def prompt(obj, results, noninteractive=False, deep=False, subprompt=False, sugg
                 break
 
 
+def print_rec_with_filter(records, field_filter):
+    """Print records filtered by field.
+
+    User determines which fields in the records to display
+    by using the --format option.
+
+    Parameters
+    ----------
+    records : list or sqlit3 cursor
+    """
+    record1 = (1, 'http://url1.com', 'title1', ',tag1,')
+    print('%s\t%s' % (record1[0], record1[1]))
+    record2 = (4, 'http://url4.com', 'title4', ',tag1,tag2,')
+    print('%s\t%s' % (record2[0], record2[1]))    
+
 def print_single_rec(row, idx=0):  # NOQA
     """Print a single DB record.
 

--- a/buku.py
+++ b/buku.py
@@ -3958,7 +3958,7 @@ POSITIONAL ARGUMENTS:
     addarg('-e', '--export', nargs=1, help=HIDE)
     addarg('-i', '--import', nargs=1, dest='importfile', help=HIDE)
     addarg('-p', '--print', nargs='*', help=HIDE)
-    addarg('-f', '--format', type=int, default=0, choices={1, 2, 3, 4}, help=HIDE)
+    addarg('-f', '--format', type=int, default=0, choices={1, 2, 3, 4, 10, 20, 30, 40}, help=HIDE)
     addarg('-j', '--json', action='store_true', help=HIDE)
     addarg('--colors', dest='colorstr', type=argparser.is_colorstr,
            default=colorstr_env if colorstr_env else 'oKlxm', metavar='COLORS', help=HIDE)

--- a/buku.py
+++ b/buku.py
@@ -1561,11 +1561,7 @@ class BukuDb:
                 return
 
             if not self.json:
-                if self.field_filter == 0:
-                    for row in results:
-                        print_single_rec(row)
-                else:
-                    print_rec_with_filter(results, self.field_filter)
+                print_rec_with_filter(results, self.field_filter)
             else:
                 print(format_json(results, True, self.field_filter))
 
@@ -1579,11 +1575,7 @@ class BukuDb:
             return
 
         if not self.json:
-            if self.field_filter == 0:
-                for row in resultset:
-                    print_single_rec(row)
-            else:
-                print_rec_with_filter(resultset, self.field_filter)
+            print_rec_with_filter(resultset, self.field_filter)
         else:
             print(format_json(resultset, field_filter=self.field_filter))
 
@@ -3203,7 +3195,7 @@ def prompt(obj, results, noninteractive=False, deep=False, subprompt=False, sugg
                 break
 
 
-def print_rec_with_filter(records, field_filter):
+def print_rec_with_filter(records, field_filter=0):
     """Print records filtered by field.
 
     User determines which fields in the records to display
@@ -3217,7 +3209,10 @@ def print_rec_with_filter(records, field_filter):
         Integer indicating which fields to print.
     """
 
-    if field_filter == 1:
+    if field_filter == 0:
+        for row in records:
+            print_single_rec(row)
+    elif field_filter == 1:
         for row in records:
             print('%s\t%s' % (row[0], row[1]))
     elif field_filter == 2:

--- a/buku.py
+++ b/buku.py
@@ -1561,17 +1561,11 @@ class BukuDb:
                 return
 
             if not self.json:
-                for row in results:
-                    if self.field_filter == 0:
+                if self.field_filter == 0:
+                    for row in results:
                         print_single_rec(row)
-                    elif self.field_filter == 1:
-                        print('%s\t%s' % (row[0], row[1]))
-                    elif self.field_filter == 2:
-                        print('%s\t%s\t%s' % (row[0], row[1], row[3][1:-1]))
-                    elif self.field_filter == 3:
-                        print('%s\t%s' % (row[0], row[2]))
-                    elif self.field_filter == 4:
-                        print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))
+                else:
+                    print_rec_with_filter(results, self.field_filter)
             else:
                 print(format_json(results, True, self.field_filter))
 
@@ -1588,18 +1582,8 @@ class BukuDb:
             if self.field_filter == 0:
                 for row in resultset:
                     print_single_rec(row)
-            elif self.field_filter == 1:
-                for row in resultset:
-                    print('%s\t%s' % (row[0], row[1]))
-            elif self.field_filter == 2:
-                for row in resultset:
-                    print('%s\t%s\t%s' % (row[0], row[1], row[3][1:-1]))
-            elif self.field_filter == 3:
-                for row in resultset:
-                    print('%s\t%s' % (row[0], row[2]))
-            elif self.field_filter == 4:
-                for row in resultset:
-                    print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))
+            else:
+                print_rec_with_filter(resultset, self.field_filter)
         else:
             print(format_json(resultset, field_filter=self.field_filter))
 
@@ -3227,8 +3211,12 @@ def print_rec_with_filter(records, field_filter):
 
     Parameters
     ----------
-    records : list or sqlit3 cursor
+    records : list or sqlite3.Cursor object
+        List of bookmark records to print
+    field_filter : int
+        Integer indicating which fields to print.        
     """
+
     if field_filter == 1:
         for row in records:
             print('%s\t%s' % (row[0], row[1]))
@@ -3241,6 +3229,18 @@ def print_rec_with_filter(records, field_filter):
     elif field_filter == 4:
         for row in records:
             print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))   
+    elif field_filter == 10:
+        for row in records:
+            print(row[1])
+    elif field_filter == 20:
+        for row in records:
+            print('%s\t%s' % (row[1], row[3][1:-1]))
+    elif field_filter == 30:
+        for row in records:
+            print(row[2])
+    elif field_filter == 40:
+        for row in records:
+            print('%s\t%s\t%s' % (row[1], row[2], row[3][1:-1]))
 
 def print_single_rec(row, idx=0):  # NOQA
     """Print a single DB record.
@@ -3935,7 +3935,7 @@ POSITIONAL ARGUMENTS:
                          -n shows the last n results (like tail)
     -f, --format N       limit fields in -p or Json search output
                          N=1: URL, N=2: URL and tag, N=3: title,
-                         N=4: URL, title and tag
+                         N=4: URL, title and tag.
     -j, --json           Json formatted output for -p and search
     --colors COLORS      set output colors in five-letter string
     --nc                 disable color output

--- a/buku.py
+++ b/buku.py
@@ -3931,7 +3931,7 @@ POSITIONAL ARGUMENTS:
     -f, --format N       limit fields in -p or Json search output
                          N=1: URL, N=2: URL and tag, N=3: title,
                          N=4: URL, title and tag. To omit DB index,
-                         use 10, 20, 30, 40 instead of 1, 2, 3, 4.
+                         use N0, e.g., 10, 20, 30, 40.
     -j, --json           Json formatted output for -p and search
     --colors COLORS      set output colors in five-letter string
     --nc                 disable color output

--- a/buku.py
+++ b/buku.py
@@ -4171,8 +4171,10 @@ POSITIONAL ARGUMENTS:
             oneshot = True
             update_search_results = True
 
-        if not args.json:
+        if not args.json and not args.format:
             prompt(bdb, search_results, oneshot, args.deep)
+        elif not args.json:
+            print_rec_with_filter(search_results, field_filter=args.format)
         else:
             # Printing in Json format is non-interactive
             print(format_json(search_results, field_filter=args.format))

--- a/buku.py
+++ b/buku.py
@@ -3214,7 +3214,7 @@ def print_rec_with_filter(records, field_filter):
     records : list or sqlite3.Cursor object
         List of bookmark records to print
     field_filter : int
-        Integer indicating which fields to print.        
+        Integer indicating which fields to print.
     """
 
     if field_filter == 1:
@@ -3228,7 +3228,7 @@ def print_rec_with_filter(records, field_filter):
             print('%s\t%s' % (row[0], row[2]))
     elif field_filter == 4:
         for row in records:
-            print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))   
+            print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))
     elif field_filter == 10:
         for row in records:
             print(row[1])

--- a/buku.py
+++ b/buku.py
@@ -3935,7 +3935,8 @@ POSITIONAL ARGUMENTS:
                          -n shows the last n results (like tail)
     -f, --format N       limit fields in -p or Json search output
                          N=1: URL, N=2: URL and tag, N=3: title,
-                         N=4: URL, title and tag.
+                         N=4: URL, title and tag. To omit DB index,
+                         use 10, 20, 30, 40 instead of 1, 2, 3, 4.
     -j, --json           Json formatted output for -p and search
     --colors COLORS      set output colors in five-letter string
     --nc                 disable color output

--- a/buku.py
+++ b/buku.py
@@ -3229,10 +3229,18 @@ def print_rec_with_filter(records, field_filter):
     ----------
     records : list or sqlit3 cursor
     """
-    record1 = (1, 'http://url1.com', 'title1', ',tag1,')
-    print('%s\t%s' % (record1[0], record1[1]))
-    record2 = (4, 'http://url4.com', 'title4', ',tag1,tag2,')
-    print('%s\t%s' % (record2[0], record2[1]))    
+    if field_filter == 1:
+        for row in records:
+            print('%s\t%s' % (row[0], row[1]))
+    elif field_filter == 2:
+        for row in records:
+            print('%s\t%s\t%s' % (row[0], row[1], row[3][1:-1]))
+    elif field_filter == 3:
+        for row in records:
+            print('%s\t%s' % (row[0], row[2]))
+    elif field_filter == 4:
+        for row in records:
+            print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))   
 
 def print_single_rec(row, idx=0):  # NOQA
     """Print a single DB record.

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -106,6 +106,43 @@ def test_parse_tags(keywords, exp_res):
     res = buku.parse_tags(keywords)
     assert res == exp_res
 
+@pytest.mark.parametrize(
+    'records, field_filter, exp_res',
+    [
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            1,
+            ['1\thttp://url1.com', '4\thttp://url4.com']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            2,
+            ['1\thttp://url1.com', '4\thttp://url4.com']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            3,
+            ['1\thttp://url1.com', '4\thttp://url4.com']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            4,
+            ['1\thttp://url1.com', '4\thttp://url4.com']
+        ]                        
+    ]
+)
+def test_print_rec_with_filter(records, field_filter, exp_res):
+    """test func."""
+    with mock.patch('buku.print', create=True) as m_print:
+        import buku
+        buku.print_rec_with_filter(records, field_filter)
+        for res in exp_res:
+            m_print.assert_any_call(res)
+
 
 @pytest.mark.parametrize(
     'taglist, exp_res',

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -112,52 +112,52 @@ def test_parse_tags(keywords, exp_res):
     [
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             1,
-            ['1\thttp://url1.com', '4\thttp://url4.com']
+            ['1\thttp://url1.com', '2\thttp://url2.com']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             2,
-            ['1\thttp://url1.com\ttag1', '4\thttp://url4.com\ttag1,tag2']
+            ['1\thttp://url1.com\ttag1', '2\thttp://url2.com\ttag1,tag2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             3,
-            ['1\ttitle1', '4\ttitle4']
+            ['1\ttitle1', '2\ttitle2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             4,
-            ['1\thttp://url1.com\ttitle1\ttag1', '4\thttp://url4.com\ttitle4\ttag1,tag2']
+            ['1\thttp://url1.com\ttitle1\ttag1', '2\thttp://url2.com\ttitle2\ttag1,tag2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             10,
-            ['http://url1.com', 'http://url4.com']
+            ['http://url1.com', 'http://url2.com']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             20,
-            ['http://url1.com\ttag1', 'http://url4.com\ttag1,tag2']
+            ['http://url1.com\ttag1', 'http://url2.com\ttag1,tag2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             30,
-            ['title1', 'title4']
+            ['title1', 'title2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
-             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+             (2, 'http://url2.com', 'title2', ',tag1,tag2,')],
             40,
-            ['http://url1.com\ttitle1\ttag1', 'http://url4.com\ttitle4\ttag1,tag2']
-        ]                                 
+            ['http://url1.com\ttitle1\ttag1', 'http://url2.com\ttitle2\ttag1,tag2']
+        ]
     ]
 )
 def test_print_rec_with_filter(records, field_filter, exp_res):

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -106,6 +106,7 @@ def test_parse_tags(keywords, exp_res):
     res = buku.parse_tags(keywords)
     assert res == exp_res
 
+
 @pytest.mark.parametrize(
     'records, field_filter, exp_res',
     [
@@ -119,25 +120,25 @@ def test_parse_tags(keywords, exp_res):
             [(1, 'http://url1.com', 'title1', ',tag1,'),
              (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
             2,
-            ['1\thttp://url1.com', '4\thttp://url4.com']
+            ['1\thttp://url1.com\ttag1', '4\thttp://url4.com\ttag1,tag2']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
              (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
             3,
-            ['1\thttp://url1.com', '4\thttp://url4.com']
+            ['1\ttitle1', '4\ttitle4']
         ],
         [
             [(1, 'http://url1.com', 'title1', ',tag1,'),
              (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
             4,
-            ['1\thttp://url1.com', '4\thttp://url4.com']
+            ['1\thttp://url1.com\ttitle1\ttag1', '4\thttp://url4.com\ttitle4\ttag1,tag2']
         ]                        
     ]
 )
 def test_print_rec_with_filter(records, field_filter, exp_res):
     """test func."""
-    with mock.patch('buku.print', create=True) as m_print:
+    with mock.patch('buku.print') as m_print:
         import buku
         buku.print_rec_with_filter(records, field_filter)
         for res in exp_res:

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -133,7 +133,31 @@ def test_parse_tags(keywords, exp_res):
              (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
             4,
             ['1\thttp://url1.com\ttitle1\ttag1', '4\thttp://url4.com\ttitle4\ttag1,tag2']
-        ]                        
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            10,
+            ['http://url1.com', 'http://url4.com']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            20,
+            ['http://url1.com\ttag1', 'http://url4.com\ttag1,tag2']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            30,
+            ['title1', 'title4']
+        ],
+        [
+            [(1, 'http://url1.com', 'title1', ',tag1,'),
+             (4, 'http://url4.com', 'title4', ',tag1,tag2,')],
+            40,
+            ['http://url1.com\ttitle1\ttag1', 'http://url4.com\ttitle4\ttag1,tag2']
+        ]                                 
     ]
 )
 def test_print_rec_with_filter(records, field_filter, exp_res):

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -162,7 +162,7 @@ def test_parse_tags(keywords, exp_res):
 )
 def test_print_rec_with_filter(records, field_filter, exp_res):
     """test func."""
-    with mock.patch('buku.print') as m_print:
+    with mock.patch('buku.print', create=True) as m_print:
         import buku
         buku.print_rec_with_filter(records, field_filter)
         for res in exp_res:


### PR DESCRIPTION
Following the discussion in https://github.com/jarun/Buku/issues/214, this PR implements a `print_rec_with_filter` function, which is called when the `--format` option is used with search options. E.g., `buku -f1 -t programming`. This fixes the current behavior where the filter is ignored when used with search options.

In addition,  this simplifies the blocks in `print_rec` that check the field filter and print the results. 

Adds field filters, `10`, `20`, `30`, `40`, which correspond to filters `1`, `2`, `3`, `4` but omit the DB index from the printed results.

A unittest, `test_print_rec_with_filter`, is added in `test_buku.py`. 

Help page, man page, and README me are updated accordingly.

