### PR TITLE
Feature/order search results by keyword matches

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2964,7 +2964,20 @@ def prep_tag_search(tags):
 
     return tags, search_operator, excluded_tags
 
-def wrap_in_case_statement(clause):
+def wrap_in_case_statement(fragment):
+    """Wraps SQL fragment in CASE statements.
+
+    Parameters
+    ----------
+    fragment : str
+        An SQL fragment
+
+    Returns
+    -------
+    str
+        SQL case statement containing the fragment.
+    """
+
     return "CASE WHEN " + clause + " THEN 1 ELSE 0 END"
 
 def gen_auto_tag():

--- a/buku.py
+++ b/buku.py
@@ -2978,7 +2978,7 @@ def wrap_in_case_statement(fragment):
         SQL case statement containing the fragment.
     """
 
-    return "CASE WHEN " + clause + " THEN 1 ELSE 0 END"
+    return "CASE WHEN " + fragment + " THEN 1 ELSE 0 END"
 
 def gen_auto_tag():
     """Generate a tag in Year-Month-Date format.

--- a/buku.py
+++ b/buku.py
@@ -1219,11 +1219,11 @@ class BukuDb:
 
         else:
             query = "SELECT id, url, metadata, tags, desc FROM (SELECT *, "
-            case_select = "CASE WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END"
-            query +=  case_select
+            case_statement = "CASE WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END"
+            query += case_statement
 
             for tag in tags[1:]:
-                query += ' + ' + case_select
+                query += ' + ' + case_statement
 
             query += ' AS score FROM bookmarks WHERE score > 0'
 

--- a/buku.py
+++ b/buku.py
@@ -1133,10 +1133,11 @@ class BukuDb:
               'desc REGEXP ?) ')
         qargs = []
 
+        case_statement = lambda x: "CASE WHEN " + x + " THEN 1 ELSE 0 END"
         if regex:
             q0 = 'SELECT id, url, metadata, tags, desc FROM (SELECT *, '
             for token in keywords:
-                q0 += wrap_in_case_statement(q2) + ' + '
+                q0 += case_statement(q2) + ' + '
                 qargs += (token, token, token, token,)
             q0 = q0[:-3] + ' AS score FROM bookmarks WHERE score > 0 ORDER BY score DESC)'
         elif all_keywords:
@@ -1161,10 +1162,10 @@ class BukuDb:
             q0 = 'SELECT id, url, metadata, tags, desc FROM (SELECT *, '
             for token in keywords:
                 if deep:
-                    q0 += wrap_in_case_statement(q1) + ' + '
+                    q0 += case_statement(q1) + ' + '
                 else:
                     token = '\\b' + token.rstrip('/') + '\\b'
-                    q0 += wrap_in_case_statement(q2) + ' + '
+                    q0 += case_statement(q2) + ' + '
                 qargs += (token, token, token, token,)
             q0 = q0[:-3] + ' AS score FROM bookmarks WHERE score > 0 ORDER BY score DESC)'
         else:
@@ -2963,22 +2964,6 @@ def prep_tag_search(tags):
     tags = [delim_wrap(t.strip()) for t in tags.split(tag_delim)]
 
     return tags, search_operator, excluded_tags
-
-def wrap_in_case_statement(fragment):
-    """Wraps SQL fragment in CASE statements.
-
-    Parameters
-    ----------
-    fragment : str
-        An SQL fragment
-
-    Returns
-    -------
-    str
-        SQL case statement containing the fragment.
-    """
-
-    return "CASE WHEN " + fragment + " THEN 1 ELSE 0 END"
 
 def gen_auto_tag():
     """Generate a tag in Year-Month-Date format.

--- a/buku.py
+++ b/buku.py
@@ -1217,18 +1217,20 @@ class BukuDb:
             query += 'ORDER BY id ASC'
 
         else:
-            query = "SELECT id, url, metadata, tags, desc,"
-            case_statement = "CASE WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END"
-            query += ' %s ' % case_statement
-            #" FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
+            query = "SELECT id, url, metadata, tags, desc FROM (SELECT *, "
+            case_select = "CASE WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END"
+            query +=  case_select
+
             for tag in tags[1:]:
-                query += ' + ' + case_statement
-            query += ' score FROM bookmarks WHERE score > 0'
+                query += ' + ' + case_select
+
+            query += ' AS score FROM bookmarks WHERE score > 0'
 
             if excluded_tags:
                 tags.append(excluded_tags)
                 query += ' AND tags NOT REGEXP ? '
-            query += ' ORDER BY score DESC'
+
+            query += ' ORDER BY score DESC)'
 
         logdbg('query: "%s", args: %s', query, tags)
         self.cur.execute(query, tuple(tags, ))

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -311,15 +311,15 @@ class TestBukuDb(unittest.TestCase):
             # Expect a list of five-element tuples containing all bookmark data
             # db index, URL, title, tags, description
             expected = [
+                (4, 'https://newbookmark.com', 'New Bookmark',
+                 parse_tags([',test,old,new,']),
+                 'additional bookmark to test multiple tag search'),
                 (1, 'http://slashdot.org', 'SLASHDOT',
                  parse_tags([',news,old,']),
                  "News for old nerds, stuff that doesn't matter"),
                 (3, 'https://test.com:8080', 'test',
                  parse_tags([',test,tes,est,es,']),
-                 "a case for replace_tag test"),
-                (4, 'https://newbookmark.com', 'New Bookmark',
-                 parse_tags([',test,old,new,']),
-                 'additional bookmark to test multiple tag search')
+                 "a case for replace_tag test")
             ]
             self.assertEqual(results, expected)
 
@@ -405,12 +405,12 @@ class TestBukuDb(unittest.TestCase):
             # Expect a list of five-element tuples containing all bookmark data
             # db index, URL, title, tags, description
             expected = [
+                (4, 'https://newbookmark.com', 'New Bookmark',
+                 parse_tags([',test,old,new,']),
+                 'additional bookmark to test multiple tag search'),
                 (1, 'http://slashdot.org', 'SLASHDOT',
                  parse_tags([',news,old,']),
                  "News for old nerds, stuff that doesn't matter"),
-                (4, 'https://newbookmark.com', 'New Bookmark',
-                 parse_tags([',test,old,new,']),
-                 'additional bookmark to test multiple tag search')
             ]
             self.assertEqual(results, expected)
 

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -309,7 +309,8 @@ class TestBukuDb(unittest.TestCase):
             # search for bookmarks matching ANY of the supplied tags
             results = self.bdb.search_by_tag('test, old')
             # Expect a list of five-element tuples containing all bookmark data
-            # db index, URL, title, tags, description
+            # db index, URL, title, tags, description, ordered by records with
+            # the most number of matches.
             expected = [
                 (4, 'https://newbookmark.com', 'New Bookmark',
                  parse_tags([',test,old,new,']),


### PR DESCRIPTION
This PR implements ordering search results by the number of keyword matches.

For example: the search query `buku -t programming, python, sql` will return a list of bookmarks that have any of the tags "programming", "python", or "sql". If there are bookmarks that have all 3 tags, they will be listed first, followed by bookmarks that have 2/3 queried tags, with bookmarks that only match one of the tags coming last.

Some specifics:
* CASE statements are used to score each bookmark. These replace ORs.
* Sub SELECT query used so that we don't return the results with the virtual "score" column.
* `search_by_tag` tests adjusted to expected results in the newly expected order.

Please let me know if anything should change!

