### PR TITLE
test for search_keywords_and_filter_by_tags method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 tests_require = [
-    'pytest-cov', 'hypothesis>=3.7.0', 'pytest>=3.4.0', 'py>=1.5.0',
+    'pytest-cov', 'hypothesis>=3.7.0', 'pytest==3.4.2', 'py>=1.5.0',
     'beautifulsoup4==4.6.0', 'flake8>=3.4.1', 'pylint>=1.7.2'
 ],
 

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1309,6 +1309,27 @@ def test_load_firefox_database(firefox_db, add_pt):
     assert call_args_list_dict == res_pickle
 
 
+@pytest.mark.parametrize(
+    'keyword_results, stag_results, exp_res',
+    [
+        ([], [], []),
+        (['item1'], ['item1', 'item2'], ['item1']),
+        (['item2'], ['item1'], []),
+    ]
+)
+def test_search_keywords_and_filter_by_tags(keyword_results, stag_results, exp_res):
+    """test method."""
+    # init
+    import buku
+    bdb = buku.BukuDb()
+    bdb.searchdb = mock.Mock(return_value=keyword_results)
+    bdb.search_by_tag = mock.Mock(return_value=stag_results)
+    # test
+    res = bdb.search_keywords_and_filter_by_tags(
+        mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), [])
+    assert exp_res == res
+
+
 # Helper functions for testcases
 
 


### PR DESCRIPTION
simple test for the method

also looking at documentation optional method paramater should have default value.

this also raise problem because variable `stag` which is not optional come after optional paramater

example

```python
def search_keywords_and_filter_by_tags(self, keywords, all_keywords=True, deep=True, regex=True, stag=None):
    """doc"""
    stag = stag is stag is not None else stag
    ...
``` 

e: also change pytest version because recent pytest fail
failed pytest version: pytest-3.5.0
travis: https://travis-ci.org/jarun/Buku/jobs/357205570

recent passed pytest version: pytest-3.4.2
travis: https://travis-ci.org/jarun/Buku/jobs/357157044

e2:error from travis

```shell
$ python3 -m pytest ./tests/test_*.py --cov buku -vv
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/pytest.py", line 13, in <module>
    from _pytest.fixtures import fixture, yield_fixture
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/_pytest/fixtures.py", line 845, in <module>
    class FixtureFunctionMarker(object):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/_pytest/fixtures.py", line 847, in FixtureFunctionMarker
    params = attr.ib(converter=attr.converters.optional(tuple))
TypeError: attrib() got an unexpected keyword argument 'converter'
```
e3: not creating bug report on pytest because i don't have minimal example for that error