### PR TITLE
exclude tests package from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     license='GPLv3',
     platforms=['any'],
     py_modules=['buku'],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     entry_points={
         'console_scripts': ['buku=buku:main', 'bukuserver=bukuserver.server:cli']


### PR DESCRIPTION
Also, in some Linux distros like Gentoo it's forbidden to install a package with the name "tests"