### PR TITLE
Feature/pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,15 @@ with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 tests_require = [
-    'pytest-cov', 'hypothesis>=3.7.0', 'py>=1.5.0',
-    'beautifulsoup4>=4.6.0', 'flake8>=3.4.1', 'pylint>=1.7.2', 'PyYAML>=3.12',
-    'pytest>=3.4.2', 'attrs>=17.4.0',
-
+    'attrs>=17.4.0',
+    'beautifulsoup4>=4.6.0',
+    'flake8>=3.4.1',
+    'hypothesis>=3.7.0',
+    'py>=1.5.0',
+    'pylint>=1.7.2',
+    'pytest-cov',
+    'pytest>=3.4.2',
+    'PyYAML>=3.12',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,10 @@ with open('README.md', encoding='utf-8') as f:
 
 tests_require = [
     'pytest-cov', 'hypothesis>=3.7.0', 'py>=1.5.0',
-    'beautifulsoup4>=4.6.0', 'flake8>=3.4.1', 'pylint>=1.7.2', 'PyYAML>=3.12'
+    'beautifulsoup4>=4.6.0', 'flake8>=3.4.1', 'pylint>=1.7.2', 'PyYAML>=3.12',
+    'pytest>=3.4.2'
+
 ]
-if sys.version_info.major == 3 and sys.version_info.minor == 6:
-    tests_require.append('pytest>=3.4.2,<=3.4.3')
-else:
-    tests_require.append('pytest>=3.4.2')
 
 
 server_require = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.md', encoding='utf-8') as f:
 tests_require = [
     'pytest-cov', 'hypothesis>=3.7.0', 'py>=1.5.0',
     'beautifulsoup4>=4.6.0', 'flake8>=3.4.1', 'pylint>=1.7.2', 'PyYAML>=3.12',
-    'pytest>=3.4.2'
+    'pytest>=3.4.2', 'attrs>=17.4.0',
 
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import warnings
+
+
+if sys.version_info.major == 3 and sys.version_info.minor == 6:
+    warnings.simplefilter('error')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,0 @@
-import sys
-import warnings
-
-
-if sys.version_info.major == 3 and sys.version_info.minor == 6:
-    warnings.simplefilter('error')

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -305,7 +305,7 @@ class TestBukuDb(unittest.TestCase):
         for i, bookmark in enumerate(self.bookmarks):
             tag_search = get_first_tag(bookmark)
             # search by the domain name for url
-            url_search = re.match('https?://(.*)?\..*', bookmark[0]).group(1)
+            url_search = re.match(r'https?://(.*)?\..*', bookmark[0]).group(1)
             title_search = bookmark[1]
             # Expect a five-tuple containing all bookmark data
             # db index, URL, title, tags, description

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -253,7 +253,8 @@ class TestBukuDb(unittest.TestCase):
         self.bdb.add_rec("https://www.google.com/ncr", "?")
         self.bdb.refreshdb(1, 1)
         from_db = self.bdb.get_rec_by_id(1)
-        self.assertEqual(from_db[2], "Google")
+        self.assertEqual(
+            from_db[2], "Google", 'from_db content: {}'.format(from_db))
 
     # @unittest.skip('skipping')
     def test_search_keywords_and_filter_by_tags(self):

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -253,8 +253,7 @@ class TestBukuDb(unittest.TestCase):
         self.bdb.add_rec("https://www.google.com/ncr", "?")
         self.bdb.refreshdb(1, 1)
         from_db = self.bdb.get_rec_by_id(1)
-        self.assertEqual(
-            from_db[2], "Google", 'from_db content: {}'.format(from_db))
+        self.assertEqual(from_db[2], "Google")
 
     # @unittest.skip('skipping')
     def test_search_keywords_and_filter_by_tags(self):


### PR DESCRIPTION
this fix latest pytest version error on python 3.6 by adding explicit attrs version

actual error message

`pytest 3.6.2 has requirement attrs>=17.4.0, but you'll have attrs 17.3.0 which is incompatible.` 

also fix a python 3.6 specific regex arg error