### PR TITLE
fix setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import os
 import re
 import shutil
 
 from setuptools import setup, find_packages
 
-shutil.copyfile('buku', 'buku.py')
+if os.path.isfile('buku'):
+    shutil.copyfile('buku', 'buku.py')
 
 with open('buku.py', encoding='utf-8') as f:
     version = re.search('__version__ = \'([^\']+)\'', f.read()).group(1)


### PR DESCRIPTION
how to recreate the bug
- create distribution file `python setup.py sdist`, result is dist/buku-4.0.tar.gz
- on empty folder create empty virtualenv
- pip install from tar.gz file
- error below

```python
Processing /home/username/git/Buku/dist/buku-4.0.post1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-hdfr3v1h/setup.py", line 13, in <module>
        shutil.copyfile('buku', 'buku.py')
      File "/home/username/envs/temp/lib/python3.6/shutil.py", line 120, in copyfile
        with open(src, 'rb') as fsrc:
    FileNotFoundError: [Errno 2] No such file or directory: 'buku'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-hdfr3v1h/
```