### PR TITLE
Fix autoimport for firefox

### DIFF
--- a/buku
+++ b/buku
@@ -2749,10 +2749,17 @@ def get_firefox_profile_name(path):
                     profile_path = config.get(name, 'path')
                     return profile_path
             except NoOptionError:
-                continue
+                pass
+            try:
+                # alternative way to detect default profile
+                if config.get(name, 'name').lower() == "default":
+                    profile_path = config.get(name, 'path')
+                    return profile_path
+            except NoOptionError:
+                pass
 
-            # There is no default profile
-            return None
+        # There is no default profile
+        return None
     else:
         logdbg('get_firefox_profile_name(): {} does not exist'.format(path))
         return None


### PR DESCRIPTION
buku --ai couldn't find profile for Firefox 52 on macOS 10.14. 

the profiles.ini looks like this:

[General] 
StartWithLastProfile=1

[Profile0]
Name=default
IsRelative=1
Path=Profiles/<REDACTED>.default

this patch adds ability to handle this.