### PR TITLE
Update tox.ini to work locally

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,6 @@ commands =
     pip install -e .[tests]
     pip install -r requirements.txt
     python -m flake8
-    echo buku | xargs pylint --rcfile tests/.pylintrc
-    find . -iname "*.py" | xargs pylint --rcfile tests/.pylintrc
-    ;find . -iname "*.py" -and -not -path './.tox/*' -not -path './build/*' | xargs pylint --rcfile tests/.pylintrc
+    pylint --rcfile tests/.pylintrc buku
+    find . -iname "*.py" -not -path "./.tox/*" -exec pylint --rcfile tests/.pylintrc \{\} +
     pytest --cov buku -vv {posargs}
-    ;pytest --cov buku -vv -m 'not slowtest and not non_tox'{posargs}


### PR DESCRIPTION
The `tox.ini` file had a few updates to get it working again:

- We can delete the commented lines, because they have already been kept inside of the Git history.
- tox does not support pipe characters in commands (https://bitbucket.org/hpk42/tox/issues/73), so we use `find -exec` and remove `xargs`
- We ignore the `.tox` directory for linting to avoid catching a bunch of imported code.