### PR TITLE
Add ability to print only title and tags with the --format option

### DIFF
--- a/buku
+++ b/buku
@@ -4002,6 +4002,9 @@ def print_rec_with_filter(records, field_filter=0):
         elif field_filter == 4:
             for row in records:
                 print('%s\t%s\t%s\t%s' % (row[0], row[1], row[2], row[3][1:-1]))
+        elif field_filter == 5:
+            for row in records:
+                print('%s\t%s\t%s' % (row[0], row[2], row[3][1:-1]))
         elif field_filter == 10:
             for row in records:
                 print(row[1])
@@ -4014,6 +4017,9 @@ def print_rec_with_filter(records, field_filter=0):
         elif field_filter == 40:
             for row in records:
                 print('%s\t%s\t%s' % (row[1], row[2], row[3][1:-1]))
+        elif field_filter == 50:
+            for row in records:
+                print('%s\t%s' % (row[2], row[3][1:-1]))
     except BrokenPipeError:
         sys.stdout = os.fdopen(1)
         sys.exit(1)
@@ -4811,7 +4817,7 @@ POSITIONAL ARGUMENTS:
     addarg('-e', '--export', nargs=1, help=hide)
     addarg('-i', '--import', nargs=1, dest='importfile', help=hide)
     addarg('-p', '--print', nargs='*', help=hide)
-    addarg('-f', '--format', type=int, default=0, choices={1, 2, 3, 4, 10, 20, 30, 40}, help=hide)
+    addarg('-f', '--format', type=int, default=0, choices={1, 2, 3, 4, 5, 10, 20, 30, 40, 50}, help=hide)
     addarg('-j', '--json', action='store_true', help=hide)
     addarg('--colors', dest='colorstr', type=argparser.is_colorstr, metavar='COLORS', help=hide)
     addarg('--nc', action='store_true', help=hide)

--- a/buku.1
+++ b/buku.1
@@ -223,9 +223,12 @@ Show selective monochrome output with specific fields. Works with --print. Searc
 = 3, show only title.
 .br
 .I N
-= 4, show URL, title and tags in a single line
+= 4, show URL, title and tags in a single line.
 .br
-To omit DB index from printed results, use N0, e.g., 10, 20, 30, 40.
+.I N
+= 5, show title and tags in a single line.
+.br
+To omit DB index from printed results, use N0, e.g., 10, 20, 30, 40, 50.
 .TP
 .BI \-j " " \--json
 Output data formatted as JSON, works with --print output and search results.


### PR DESCRIPTION
Simple modification to add an addition `--format` option to only print the title and tags.