### PR TITLE
new: dev: use custom ca certs

### DIFF
--- a/buku
+++ b/buku
@@ -4225,19 +4225,20 @@ def check_upstream_release():
     if MYPROXY is None:
         gen_headers()
 
+    ca_certs = os.getenv('BUKU_CA_CERTS', default=certifi.where())
     if MYPROXY:
         manager = urllib3.ProxyManager(
             MYPROXY,
             num_pools=1,
             headers=MYHEADERS,
             cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where()
+            ca_certs=ca_certs
         )
     else:
         manager = urllib3.PoolManager(num_pools=1,
                                       headers={'User-Agent': USER_AGENT},
                                       cert_reqs='CERT_REQUIRED',
-                                      ca_certs=certifi.where())
+                                      ca_certs=ca_certs)
 
     try:
         r = manager.request(

--- a/buku
+++ b/buku
@@ -3393,17 +3393,17 @@ def get_PoolManager():
     ProxyManager or PoolManager
         ProxyManager if https_proxy is defined, PoolManager otherwise.
     """
-
+    ca_certs = os.getenv('BUKU_CA_CERTS', default=certifi.where())
     if MYPROXY:
         return urllib3.ProxyManager(MYPROXY, num_pools=1, headers=MYHEADERS, timeout=15,
-                                    cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
+                                    cert_reqs='CERT_REQUIRED', ca_certs=ca_certs)
 
     return urllib3.PoolManager(
         num_pools=1,
         headers=MYHEADERS,
         timeout=15,
         cert_reqs='CERT_REQUIRED',
-        ca_certs=certifi.where())
+        ca_certs=ca_certs)
 
 
 def network_handler(url, http_head=False):

--- a/buku
+++ b/buku
@@ -2547,18 +2547,19 @@ class BukuDb:
         if MYPROXY is None:
             gen_headers()
 
+        ca_certs = os.getenv('BUKU_CA_CERTS', default=certifi.where())
         if MYPROXY:
             manager = urllib3.ProxyManager(
                 MYPROXY,
                 num_pools=1,
                 headers=MYHEADERS,
                 cert_reqs='CERT_REQUIRED',
-                ca_certs=certifi.where())
+                ca_certs=ca_certs)
         else:
             manager = urllib3.PoolManager(num_pools=1,
                                           headers={'User-Agent': USER_AGENT},
                                           cert_reqs='CERT_REQUIRED',
-                                          ca_certs=certifi.where())
+                                          ca_certs=ca_certs)
 
         try:
             r = manager.request(


### PR DESCRIPTION
fix #361 

to use custom certificate set `BUKU_CA_CERTS` env variable to your certificate path.

@ranebrown

@jarun it is simplest config i can think of. other alternative is to create parameter  for custom certificate but it require to refactoring buku. 

e: also no test for now, if i find method on how to check custom certificate, i will add it later