### PR TITLE
chg: dev: requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-beautifulsoup4>=4.4.1
-certifi
-cryptography>=1.2.3
 setuptools
-urllib3>=1.23
+.


### PR DESCRIPTION
this is to let requirements.txt list the package on setup.py. this way there is only single place to update package (setup.py)

reference

https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py

at first i thought this can be replaced with single dot character, but `setuptools` actually a bit trickier

there is an alternative on how to install setuptools at link below but it is a lot more (unnecessary) work just to replace the requirements.txt

https://stackoverflow.com/a/48129284/1766261

so in the end setuptools is stay as required package on requirements.txt and other package will be listed on setup.py