### PR TITLE
Feature/fix python3.7

### DIFF
--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1107,7 +1107,7 @@ def test_update_rec_exec_arg(caplog, kwargs, exp_query, exp_query_p37, exp_argum
 
 
 @pytest.mark.parametrize(
-    'tags_to_search, exp_query, exp_query_p37, exp_arguments',
+    'tags_to_search, exp_query, exp_query_p37, exp_arguments, exp_arguments_p37',
     [
         [
             'tag1, tag2',
@@ -1117,7 +1117,8 @@ def test_update_rec_exec_arg(caplog, kwargs, exp_query, exp_query_p37, exp_argum
             "FROM (SELECT *, CASE WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END + CASE "
             "WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END AS score "
             "FROM bookmarks WHERE score > 0 ORDER BY score DESC)",
-            [',tag1,', ',tag2,']
+            [',tag1,', ',tag2,'],
+            None
         ],
         [
             'tag2+tag2,tag3, tag4',
@@ -1128,30 +1129,35 @@ def test_update_rec_exec_arg(caplog, kwargs, exp_query, exp_query_p37, exp_argum
             "WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END + CASE "
             "WHEN tags LIKE '%' || ? || '%' THEN 1 ELSE 0 END AS score "
             "FROM bookmarks WHERE score > 0 ORDER BY score DESC)",
-            [',tag1+tag2,', ',tag3,', ',tag4,']
+            [',tag1+tag2,', ',tag3,', ',tag4,'],
+            [',tag2+tag2,', ',tag3,', ',tag4,']
         ],
         [
             'tag1 + tag2+tag3',
             "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
             "AND tags LIKE '%' || ? || '%' ORDER BY id ASC",
             None,
-            [',tag1,', ',tag2+tag3,']
+            [',tag1,', ',tag2+tag3,'],
+            None
         ],
         [
             'tag1-tag2 + tag 3 - tag4',
             "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE (tags LIKE '%' || ? || '%' "
             "AND tags LIKE '%' || ? || '%' ) AND tags NOT REGEXP ? ORDER BY id ASC",
             None,
-            [',tag1-tag2,', ',tag 3,', ',tag4,']
+            [',tag1-tag2,', ',tag 3,', ',tag4,'],
+            None
         ]
     ]
 )
-def test_search_by_tag_query(caplog, tags_to_search, exp_query, exp_query_p37, exp_arguments):
+def test_search_by_tag_query(caplog, tags_to_search, exp_query, exp_query_p37, exp_arguments, exp_arguments_p37):
     """test that the correct query and argments are constructed"""
     if (sys.version_info.major, sys.version_info.minor) == (3, 7):
         caplog.set_level(logging.DEBUG)
         if exp_query_p37:
             exp_query = exp_query_p37
+        if exp_arguments_p37:
+            exp_arguments = exp_arguments_p37
     bdb = BukuDb()
     bdb.search_by_tag(tags_to_search)
     exp_log = 'query: "{}", args: {}'.format(exp_query, exp_arguments)

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1120,7 +1120,7 @@ def test_update_rec_exec_arg(caplog, kwargs, exp_query, exp_query_p37, exp_argum
             [',tag1,', ',tag2,']
         ],
         [
-            'tag1+tag2,tag3, tag4',
+            'tag2+tag2,tag3, tag4',
             "SELECT id, url, metadata, tags, desc FROM bookmarks WHERE tags LIKE '%' || ? || '%' "
             "OR tags LIKE '%' || ? || '%' OR tags LIKE '%' || ? || '%' ORDER BY id ASC",
             "SELECT id, url, metadata, tags, desc "
@@ -1207,6 +1207,8 @@ def test_update_rec_invalid_tag(caplog, invalid_tag):
 @pytest.mark.parametrize('read_in_retval', ['y', 'n', ''])
 def test_update_rec_update_all_bookmark(caplog, read_in_retval):
     """test method."""
+    if (sys.version_info.major, sys.version_info.minor) == (3, 7):
+        caplog.set_level(logging.DEBUG)
     with mock.patch('buku.read_in', return_value=read_in_retval):
         import buku
         bdb = buku.BukuDb()
@@ -1216,8 +1218,12 @@ def test_update_rec_update_all_bookmark(caplog, read_in_retval):
             return
         assert res
         try:
-            assert caplog.records[0].getMessage() == \
-                   'query: "UPDATE bookmarks SET tags = ?", args: [\',tags1\']'
+            if (sys.version_info.major, sys.version_info.minor) == (3, 7):
+                assert caplog.records[0].getMessage() == \
+                       'update_rec query: "UPDATE bookmarks SET tags = ?", args: [\',tags1,\']'
+            else:
+                assert caplog.records[0].getMessage() == \
+                       'query: "UPDATE bookmarks SET tags = ?", args: [\',tags1\']'
             assert caplog.records[0].levelname == 'DEBUG'
         except IndexError as e:
             # TODO: fix test


### PR DESCRIPTION
fix #371 

there are several behaviour change on python 3.7 (and maybe for future python version)

- caplog have to set manually to debug level
- the way we have test with using logging is depend on how the function generate it. so if it change even a little bit (comma, period, newline, etc) it will require change to test
- please see the db sql line. i have no idea why it is changed and different from the old python version

e: can't find where the debug level change on pytest's caplog but the solution is taken from here https://github.com/pytest-dev/pytest/issues/3226
e2: look like there is a change on search_by_tag_query argument