### PR TITLE
Feature/test exportdb

### DIFF
--- a/buku
+++ b/buku
@@ -49,7 +49,7 @@ from urllib3.util import parse_url, make_headers
 try:
     from mypy_extensions import TypedDict
 except ImportError:
-    TypedDict = None
+    TypedDict = None  # type: ignore
 
 __version__ = '4.1'
 __author__ = 'Arun Prakash Jana <engineerarun@gmail.com>'
@@ -331,6 +331,9 @@ class BukuCrypt:
         except Exception as e:
             LOGERR(e)
             sys.exit(1)
+
+
+BookmarkVar = Tuple[int, str, str, str, str, int]
 
 
 class BukuDb:
@@ -2032,7 +2035,7 @@ class BukuDb:
 
         return False
 
-    def exportdb(self, filepath: str, resultset: Optional[List[Tuple[Any, Any, Any, Any, Any, Any]]] = None) -> bool:
+    def exportdb(self, filepath: str, resultset: Optional[List[BookmarkVar]] = None) -> bool:
         """Export DB bookmarks to file.
         Exports full DB, if resultset is None
 
@@ -2092,6 +2095,7 @@ class BukuDb:
             LOGERR(e)
             return False
 
+        res = {}  # type: Dict
         if filepath.endswith('.md'):
             res = convert_bookmark_set(resultset, 'markdown')
             count += res['count']
@@ -2767,8 +2771,8 @@ ConverterResult = TypedDict('ConverterResult', {'data': str, 'count': int}) if T
 
 
 def convert_bookmark_set(
-        bookmark_set: List[Tuple[Any, Any, Any, Any, Any, Any]],
-        export_type: str) -> ConverterResult:
+        bookmark_set: List[BookmarkVar],
+        export_type: str) -> ConverterResult:  # type: ignore
     """Convert list of bookmark set into multiple data format.
 
     Parameters

--- a/buku
+++ b/buku
@@ -2077,12 +2077,9 @@ class BukuDb:
             qry = 'INSERT INTO bookmarks(URL, metadata, tags, desc, flags) VALUES (?, ?, ?, ?, ?)'
             for row in resultset:
                 outdb.cur.execute(qry, (row[1], row[2], row[3], row[4], row[5]))
+                count += 1
             outdb.conn.commit()
             outdb.close()
-
-            count = self.get_max_id()
-            if count == -1:
-                count = 0
             print('%s exported' % count)
             return True
 

--- a/buku
+++ b/buku
@@ -2800,9 +2800,9 @@ def convert_bookmark_set(
     elif export_type == 'org':
         for row in resultset:
             if row[2] == '':
-                out += '- [Untitled](' + row[1] + ')\n'
+                out += '* [[{}][Untitled]]\n'.format(row[1])
             else:
-                out += '- [' + row[2] + '](' + row[1] + ')\n'
+                out += '* [[{}][{}]]\n'.format(row[1], row[2])
             count += 1
     elif export_type == 'html':
         timestamp = str(int(time.time()))

--- a/buku
+++ b/buku
@@ -43,10 +43,10 @@ except ImportError:
     pass
 from bs4 import BeautifulSoup
 import certifi
-from mypy_extensions import TypedDict
 import urllib3
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url, make_headers
+from mypy_extensions import TypedDict
 
 __version__ = '4.1'
 __author__ = 'Arun Prakash Jana <engineerarun@gmail.com>'
@@ -2805,9 +2805,9 @@ def convert_bookmark_set(
             '<TITLE>Bookmarks</TITLE>\n'
             '<H1>Bookmarks</H1>\n\n'
             '<DL><p>\n'
-            '    <DT><H3 ADD_DATE="%s" LAST_MODIFIED="%s" '
+            '    <DT><H3 ADD_DATE="{0}" LAST_MODIFIED="{0}" '
             'PERSONAL_TOOLBAR_FOLDER="true">Buku bookmarks</H3>\n'
-            '    <DL><p>\n'.format(timestamp, timestamp))
+            '    <DL><p>\n'.format(timestamp))
 
         for row in resultset:
             out += ('        <DT><A HREF="%s" ADD_DATE="%s" LAST_MODIFIED="%s"' % (row[1], timestamp, timestamp))

--- a/buku
+++ b/buku
@@ -34,7 +34,7 @@ from subprocess import Popen, PIPE, DEVNULL
 import sys
 import threading
 import time
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import webbrowser
 try:
     import readline
@@ -46,7 +46,10 @@ import certifi
 import urllib3
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url, make_headers
-from mypy_extensions import TypedDict
+try:
+    from mypy_extensions import TypedDict
+except ImportError:
+    TypedDict = None
 
 __version__ = '4.1'
 __author__ = 'Arun Prakash Jana <engineerarun@gmail.com>'
@@ -2760,7 +2763,7 @@ PROMPT KEYS:
 # ----------------
 
 
-ConverterResult = TypedDict('ConverterResult', {'data': str, 'count': int})
+ConverterResult = TypedDict('ConverterResult', {'data': str, 'count': int}) if TypedDict else Dict[str, Any]
 
 
 def convert_bookmark_set(

--- a/buku
+++ b/buku
@@ -34,6 +34,7 @@ from subprocess import Popen, PIPE, DEVNULL
 import sys
 import threading
 import time
+from typing import Any, Optional, Tuple
 import webbrowser
 try:
     import readline
@@ -343,7 +344,9 @@ class BukuDb:
         Sets the verbosity of the APIs. Default is False.
     """
 
-    def __init__(self, json=False, field_filter=0, chatty=False, dbfile=None, colorize=True):
+    def __init__(
+            self, json: Optional[bool] = False, field_filter: Optional[int] = 0, chatty: Optional[bool] = False,
+            dbfile: Optional[str] = None, colorize: Optional[bool] = True) -> None:
         """Database initialization API.
 
         Parameters
@@ -394,7 +397,7 @@ class BukuDb:
         return os.path.join(data_home, 'buku')
 
     @staticmethod
-    def initdb(dbfile=None, chatty=False):
+    def initdb(dbfile: Optional[str]=None, chatty: Optional[bool]=False) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
         """Initialize the database connection.
 
         Create DB file and/or bookmarks table if they don't exist.
@@ -530,13 +533,13 @@ class BukuDb:
 
     def add_rec(
             self,
-            url,
-            title_in=None,
-            tags_in=None,
-            desc=None,
-            immutable=0,
-            delay_commit=False,
-            fetch=True):
+            url: str,
+            title_in: Optional[str] = None,
+            tags_in: Optional[str] = None,
+            desc: Optional[str] = None,
+            immutable: Optional[int] = 0,
+            delay_commit: Optional[bool]=False,
+            fetch: Optional[bool] = True) -> int:
         """Add a new bookmark.
 
         Parameters
@@ -2025,7 +2028,7 @@ class BukuDb:
 
         return False
 
-    def exportdb(self, filepath, resultset=None):
+    def exportdb(self, filepath: str, resultset: Optional[Tuple[Any]]=None) -> bool:
         """Export DB bookmarks to file.
         Exports full DB, if resultset is None
 

--- a/buku
+++ b/buku
@@ -397,7 +397,7 @@ class BukuDb:
         return os.path.join(data_home, 'buku')
 
     @staticmethod
-    def initdb(dbfile: Optional[str]=None, chatty: Optional[bool]=False) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
+    def initdb(dbfile: Optional[str] = None, chatty: Optional[bool] = False) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
         """Initialize the database connection.
 
         Create DB file and/or bookmarks table if they don't exist.
@@ -538,7 +538,7 @@ class BukuDb:
             tags_in: Optional[str] = None,
             desc: Optional[str] = None,
             immutable: Optional[int] = 0,
-            delay_commit: Optional[bool]=False,
+            delay_commit: Optional[bool] = False,
             fetch: Optional[bool] = True) -> int:
         """Add a new bookmark.
 
@@ -2028,7 +2028,7 @@ class BukuDb:
 
         return False
 
-    def exportdb(self, filepath: str, resultset: Optional[Tuple[Any]]=None) -> bool:
+    def exportdb(self, filepath: str, resultset: Optional[Tuple[Any]] = None) -> bool:
         """Export DB bookmarks to file.
         Exports full DB, if resultset is None
 

--- a/buku
+++ b/buku
@@ -34,7 +34,7 @@ from subprocess import Popen, PIPE, DEVNULL
 import sys
 import threading
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 import webbrowser
 try:
     import readline

--- a/buku
+++ b/buku
@@ -43,6 +43,7 @@ except ImportError:
     pass
 from bs4 import BeautifulSoup
 import certifi
+from mypy_extensions import TypedDict
 import urllib3
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url, make_headers
@@ -2762,7 +2763,12 @@ PROMPT KEYS:
 # ----------------
 
 
-def convert_bookmark_set(bookmark_set: List[Tuple[Any, Any, Any, Any, Any, Any]], export_type: str) -> Dict[str, Any]:
+ConverterResult = TypedDict('ConverterResult', {'data': str, 'count': int})
+
+
+def convert_bookmark_set(
+        bookmark_set: List[Tuple[Any, Any, Any, Any, Any, Any]],
+        export_type: str) -> ConverterResult:
     """Convert list of bookmark set into multiple data format.
 
     Parameters

--- a/buku
+++ b/buku
@@ -34,7 +34,7 @@ from subprocess import Popen, PIPE, DEVNULL
 import sys
 import threading
 import time
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import webbrowser
 try:
     import readline
@@ -2028,7 +2028,7 @@ class BukuDb:
 
         return False
 
-    def exportdb(self, filepath: str, resultset: Optional[Tuple[Any]] = None) -> bool:
+    def exportdb(self, filepath: str, resultset: Optional[List[Tuple[Any, Any, Any, Any, Any, Any]]] = None) -> bool:
         """Export DB bookmarks to file.
         Exports full DB, if resultset is None
 
@@ -2056,7 +2056,6 @@ class BukuDb:
         """
 
         count = 0
-        timestamp = str(int(time.time()))
 
         if not resultset:
             resultset = self.get_rec_all()
@@ -2093,47 +2092,17 @@ class BukuDb:
             return False
 
         if filepath.endswith('.md'):
-            for row in resultset:
-                if row[2] == '':
-                    out = '- [Untitled](' + row[1] + ')\n'
-                else:
-                    out = '- [' + row[2] + '](' + row[1] + ')\n'
-                outfp.write(out)
-                count += 1
-
+            res = convert_bookmark_set(resultset, 'markdown')
+            count += res['count']
+            outfp.write(res['data'])
         elif filepath.endswith('.org'):
-            for row in resultset:
-                if row[2] == '':
-                    out = '* [[{}][Untitled]]\n'.format(row[1])
-                else:
-                    out = '* [[{}][{}]]\n'.format(row[1], row[2])
-                outfp.write(out)
-                count += 1
+            res = convert_bookmark_set(resultset, 'org')
+            count += res['count']
+            outfp.write(res['data'])
         else:
-            outfp.write('<!DOCTYPE NETSCAPE-Bookmark-file-1>\n\n'
-                        '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">\n'
-                        '<TITLE>Bookmarks</TITLE>\n'
-                        '<H1>Bookmarks</H1>\n\n'
-                        '<DL><p>\n'
-                        '    <DT><H3 ADD_DATE="%s" LAST_MODIFIED="%s" '
-                        'PERSONAL_TOOLBAR_FOLDER="true">Buku bookmarks</H3>\n'
-                        '    <DL><p>\n'
-                        % (timestamp, timestamp))
-
-            for row in resultset:
-                out = ('        <DT><A HREF="%s" ADD_DATE="%s" LAST_MODIFIED="%s"'
-                       % (row[1], timestamp, timestamp))
-                if row[3] != DELIM:
-                    out += ' TAGS="' + row[3][1:-1] + '"'
-                out += '>' + row[2] + '</A>\n'
-                if row[4] != '':
-                    out += '        <DD>' + row[4] + '\n'
-
-                outfp.write(out)
-                count += 1
-
-            outfp.write('    </DL><p>\n</DL><p>')
-
+            res = convert_bookmark_set(resultset, 'html')
+            count += res['count']
+            outfp.write(res['data'])
         outfp.close()
         print('%s exported' % count)
         return True
@@ -2791,6 +2760,65 @@ PROMPT KEYS:
 # ----------------
 # Helper functions
 # ----------------
+
+
+def convert_bookmark_set(bookmark_set: List[Tuple[Any, Any, Any, Any, Any, Any]], export_type: str) -> Dict[str, Any]:
+    """Convert list of bookmark set into multiple data format.
+
+    Parameters
+    ----------
+        bookmark_set: bookmark set
+        export type: one of supported type: markdown, html, org
+
+    Returns
+    -------
+        converted data and count of converted bookmark set
+    """
+    assert export_type in ['markdown', 'html', 'org']
+    #  compatibility
+    resultset = bookmark_set
+
+    count = 0
+    out = ''
+    if export_type == 'markdown':
+        for row in resultset:
+            if row[2] == '':
+                out += '- [Untitled](' + row[1] + ')\n'
+            else:
+                out += '- [' + row[2] + '](' + row[1] + ')\n'
+            count += 1
+    elif export_type == 'org':
+        for row in resultset:
+            if row[2] == '':
+                out += '- [Untitled](' + row[1] + ')\n'
+            else:
+                out += '- [' + row[2] + '](' + row[1] + ')\n'
+            count += 1
+    elif export_type == 'html':
+        timestamp = str(int(time.time()))
+        out = (
+            '<!DOCTYPE NETSCAPE-Bookmark-file-1>\n\n'
+            '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">\n'
+            '<TITLE>Bookmarks</TITLE>\n'
+            '<H1>Bookmarks</H1>\n\n'
+            '<DL><p>\n'
+            '    <DT><H3 ADD_DATE="%s" LAST_MODIFIED="%s" '
+            'PERSONAL_TOOLBAR_FOLDER="true">Buku bookmarks</H3>\n'
+            '    <DL><p>\n'.format(timestamp, timestamp))
+
+        for row in resultset:
+            out += ('        <DT><A HREF="%s" ADD_DATE="%s" LAST_MODIFIED="%s"' % (row[1], timestamp, timestamp))
+            if row[3] != DELIM:
+                out += ' TAGS="' + row[3][1:-1] + '"'
+            out += '>' + row[2] + '</A>\n'
+            if row[4] != '':
+                out += '        <DD>' + row[4] + '\n'
+            count += 1
+
+        out += '    </DL><p>\n</DL><p>'
+
+    return {'data': out, 'count': count}
+
 
 def get_firefox_profile_name(path):
     """List folder and detect default Firefox profile name.

--- a/buku
+++ b/buku
@@ -518,7 +518,7 @@ class BukuDb:
         resultset = self.cur.fetchall()
         return resultset[0][0] if resultset else -1
 
-    def get_max_id(self):
+    def get_max_id(self) -> int:
         """Fetch the ID of the last record.
 
         Returns

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -14,7 +14,7 @@ from flask_paginate import Pagination, get_page_parameter, get_per_page_paramete
 from markupsafe import Markup
 import click
 import flask
-from flask import (
+from flask import (  # type: ignore
     __version__ as flask_version,
     abort,
     current_app,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+# use setup.py for latest required package 
+beautifulsoup4>=4.4.1
+certifi
+cryptography>=1.2.3
+html5lib>=1.0.1
 setuptools
-.
+urllib3>=1.23

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.isfile('buku'):
     shutil.copyfile('buku', 'buku.py')
 
 with open('buku.py', encoding='utf-8') as f:
-    version = re.search('__version__ = \'([^\']+)\'', f.read()).group(1)
+    version = re.search('__version__ = \'([^\']+)\'', f.read()).group(1)  # type: ignore
 
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
@@ -25,6 +25,7 @@ tests_require = [
     'pytest-cov',
     'pytest>=3.4.2',
     'PyYAML>=4.2b1',
+    'setuptools>=41.0.1',
     'vcrpy>=1.13.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ tests_require = [
     'beautifulsoup4>=4.6.0',
     'flake8>=3.4.1',
     'hypothesis>=3.7.0',
+    'mypy-extensions==0.4.1',
     'py>=1.5.0',
     'pylint>=1.7.2',
     'pytest-cov',

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -762,4 +762,3 @@ def test_convert_bookmark_set(export_type, exp_res, monkeypatch):
         res = convert_bookmark_set(bms, export_type=export_type)
         assert res['count'] == 2
         assert exp_res == res['data']
-

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -727,3 +727,39 @@ def test_copy_to_clipboard(platform, params):
             m_popen_retval.communicate.assert_called_once_with(content)
         else:
             m_popen.assert_not_called()
+
+
+@pytest.mark.parametrize('export_type, exp_res', [
+    [
+        'html',
+        '<!DOCTYPE NETSCAPE-Bookmark-file-1>\n\n'
+        '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">\n'
+        '<TITLE>Bookmarks</TITLE>\n<H1>Bookmarks</H1>\n\n<DL><p>\n'
+        '    <DT><H3 ADD_DATE="1556430615" LAST_MODIFIED="1556430615" PERSONAL_TOOLBAR_FOLDER="true">Buku bookmarks</H3>\n'
+        '    <DL><p>\n'
+        '        <DT><A HREF="htttp://example.com" ADD_DATE="1556430615" LAST_MODIFIED="1556430615"></A>\n'
+        '        <DT><A HREF="http://google.com" ADD_DATE="1556430615" LAST_MODIFIED="1556430615">Google</A>\n'
+        '    </DL><p>\n</DL><p>'
+    ],
+    ['org', '- [Untitled](htttp://example.com)\n- [Google](http://google.com)\n'],
+    ['markdown', '- [Untitled](htttp://example.com)\n- [Google](http://google.com)\n'],
+    ['random', None],
+])
+def test_convert_bookmark_set(export_type, exp_res, monkeypatch):
+    from buku import convert_bookmark_set
+    import buku
+    bms = [
+        (1, 'htttp://example.com', '', ',', '', 0),
+        (2, 'http://google.com', 'Google', ',', '', 0)]
+    if export_type == 'random':
+        with pytest.raises(AssertionError):
+            convert_bookmark_set(bms, export_type=export_type)
+    else:
+
+        def return_fixed_number():
+            return 1556430615
+        monkeypatch.setattr(buku.time, 'time', return_fixed_number)
+        res = convert_bookmark_set(bms, export_type=export_type)
+        assert res['count'] == 2
+        assert exp_res == res['data']
+

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -741,7 +741,7 @@ def test_copy_to_clipboard(platform, params):
         '        <DT><A HREF="http://google.com" ADD_DATE="1556430615" LAST_MODIFIED="1556430615">Google</A>\n'
         '    </DL><p>\n</DL><p>'
     ],
-    ['org', '- [Untitled](htttp://example.com)\n- [Google](http://google.com)\n'],
+    ['org', '* [[htttp://example.com][Untitled]]\n* [[http://google.com][Google]]\n'],
     ['markdown', '- [Untitled](htttp://example.com)\n- [Google](http://google.com)\n'],
     ['random', None],
 ])

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1435,6 +1435,17 @@ def test_exportdb_single_rec(tmpdir):
             assert f.read()
 
 
+def test_exportdb_to_db():
+    with NamedTemporaryFile(delete=False) as f1, NamedTemporaryFile(delete=False, suffix='.db') as f2:
+        db = BukuDb(dbfile=f1.name)
+        db.add_rec('http://example.com')
+        db.add_rec('http://google.com')
+        with mock.patch('builtins.input', return_value='y'):
+            db.exportdb(f2.name)
+        db2 = BukuDb(dbfile=f2.name)
+        assert db.get_rec_all() == db2.get_rec_all()
+
+
 @pytest.mark.parametrize(
     'urls, exp_res',
     [

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -13,7 +13,7 @@ import urllib
 import zipfile
 from genericpath import exists
 from itertools import product
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from unittest import mock
 import unittest
@@ -1415,6 +1415,24 @@ def test_exclude_results_from_search(search_results, exclude_results, exp_res):
     res = bdb.exclude_results_from_search(
         search_results, [], True)
     assert exp_res == res
+
+
+def test_exportdb_empty_db():
+    with NamedTemporaryFile(delete=False) as f:
+        db = BukuDb(dbfile=f.name)
+        with NamedTemporaryFile(delete=False) as f2:
+            res = db.exportdb(f2.name)
+            assert not res
+
+
+def test_exportdb_single_rec(tmpdir):
+    with NamedTemporaryFile(delete=False) as f:
+        db = BukuDb(dbfile=f.name)
+        db.add_rec('http://example.com')
+        exp_file = tmpdir.join('export')
+        db.exportdb(exp_file.strpath)
+        with open(exp_file) as f:
+            assert f.read()
 
 
 # Helper functions for testcases

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1431,7 +1431,7 @@ def test_exportdb_single_rec(tmpdir):
         db.add_rec('http://example.com')
         exp_file = tmpdir.join('export')
         db.exportdb(exp_file.strpath)
-        with open(exp_file) as f:
+        with open(exp_file.strpath) as f:
             assert f.read()
 
 

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1435,6 +1435,21 @@ def test_exportdb_single_rec(tmpdir):
             assert f.read()
 
 
+@pytest.mark.parametrize(
+    'urls, exp_res',
+    [
+        [[], -1],
+        [['http://example.com'], 1],
+        [['htttp://example.com', 'http://google.com'], 2],
+    ])
+def test_get_max_id(urls, exp_res):
+    with NamedTemporaryFile(delete=False) as f:
+        db = BukuDb(dbfile=f.name)
+        if urls:
+            list(map(lambda x: db.add_rec(x), urls))
+        assert db.get_max_id() == exp_res
+
+
 # Helper functions for testcases
 
 


### PR DESCRIPTION
- [x] export db with empty db
- [x] simple export db with single record
- [x] test content
- [x] test export to other db
- [x] copy required package to requirements.txt
- [x] update setuptools requirement. see https://github.com/di/markdown-description-example/issues/4 

test content is harder because it is depend on record. i propose to split this into another function so it can be easily tested

i also use mypy annotation to help me remembering/checking input/output but no test for this yet for circleci. if this is approved i will add the configuration 

e: also when exporting to other db

```
if filepath.endswith('.db'):
    ...
    count = self.get_max_id()
    if count == -1:
        count = 0
    print('%s exported' % count)
    return True
```

- not sure why checking max id on current db
- the count should be based on number of executed query instead of max id right?

unrelated to above, 

- will it be better instead of removing existing database move it to trash using send2trash
- do we have func/feature to export record(s) to other db?

e2: this is mock up to split the bookmark set converter https://github.com/rachmadaniHaryono/Buku/tree/feature/split-convert-bookmark-set