### PR TITLE
Add Waterfox import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are several [projects based on `buku`](#related-projects), including a bro
 ### Features
 
 - Store bookmarks with auto-fetched title, tags and description
-- Auto-import from Firefox, Google Chrome and Chromium
+- Auto-import from Firefox, Waterfox, Google Chrome and Chromium
 - Open bookmarks and search results in browser
 - Shorten, expand URLs, browse cached page from Wayback Machine
 - Text editor integration
@@ -217,7 +217,7 @@ ENCRYPTION OPTIONS:
       -k, --unlock [N]     decrypt DB in N (default 8) # iterations
 
 POWER TOYS:
-      --ai                 auto-import from Firefox/Chrome/Chromium
+      --ai                 auto-import from Firefox/Waterfox/Chrome/Chromium
       -e, --export file    export bookmarks to Firefox format HTML
                            export Markdown, if file ends with '.md'
                            format: [title](url), 1 entry per line

--- a/buku
+++ b/buku
@@ -2253,7 +2253,7 @@ class BukuDb:
     def auto_import_from_browser(self):
         """Import bookmarks from a browser default database file.
 
-        Supports Firefox and Google Chrome.
+        Supports Firefox, Waterfox and Google Chrome.
 
         Returns
         -------
@@ -2271,6 +2271,11 @@ class BukuDb:
             profile = get_firefox_profile_name(default_ff_folder)
             if profile:
                 ff_bm_db_path = '~/.mozilla/firefox/{}/places.sqlite'.format(profile)
+
+            default_wf_folder = os.path.expanduser('~/.waterfox')
+            profile = get_firefox_profile_name(default_wf_folder)
+            if profile:
+                wf_bm_db_path = '~/.waterfox/{}/places.sqlite'.format(profile)
         elif sys.platform == 'darwin':
             gc_bm_db_path = '~/Library/Application Support/Google/Chrome/Default/Bookmarks'
             cb_bm_db_path = '~/Library/Application Support/Chromium/Default/Bookmarks'
@@ -2279,6 +2284,12 @@ class BukuDb:
             profile = get_firefox_profile_name(default_ff_folder)
             if profile:
                 ff_bm_db_path = ('~/Library/Application Support/Firefox/'
+                                 '{}/places.sqlite'.format(profile))
+
+            default_wf_folder = os.path.expanduser('~/Library/Application Support/Waterfox')
+            profile = get_firefox_profile_name(default_wf_folder)
+            if profile:
+                wf_bm_db_path = ('~/Library/Application Support/Waterfox/'
                                  '{}/places.sqlite'.format(profile))
         elif sys.platform == 'win32':
             username = os.getlogin()
@@ -2291,6 +2302,11 @@ class BukuDb:
             profile = get_firefox_profile_name(default_ff_folder)
             if profile:
                 ff_bm_db_path = os.path.join(default_ff_folder, '{}/places.sqlite'.format(profile))
+
+            default_wf_folder = 'C:/Users/{}/AppData/Roaming/Waterfox/'.format(username)
+            profile = get_firefox_profile_name(default_wf_folder)
+            if profile:
+                wf_bm_db_path = os.path.join(default_wf_folder, '{}/places.sqlite'.format(profile))
         else:
             LOGERR('Buku does not support {} yet'.format(sys.platform))
             self.close_quit(1)
@@ -2337,6 +2353,17 @@ class BukuDb:
                 self.load_firefox_database(bookmarks_database, newtag, add_parent_folder_as_tag)
         except Exception:
             print('Could not import bookmarks from Firefox.')
+
+        try:
+            if self.chatty:
+                resp = input('Import bookmarks from Waterfox? (y/n): ')
+            if resp == 'y':
+                bookmarks_database = os.path.expanduser(wf_bm_db_path)
+                if not os.path.exists(bookmarks_database):
+                    raise FileNotFoundError
+                self.load_firefox_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+        except Exception:
+            print('Could not import bookmarks from Waterfox.')
 
         self.conn.commit()
 
@@ -4813,7 +4840,7 @@ POSITIONAL ARGUMENTS:
 
     power_grp = argparser.add_argument_group(
         title='POWER TOYS',
-        description='''    --ai                 auto-import from Firefox/Chrome/Chromium
+        description='''    --ai                 auto-import from Firefox/Waterfox/Chrome/Chromium
     -e, --export file    export bookmarks to Firefox format HTML
                          export Markdown, if file ends with '.md'
                          format: [title](url), 1 entry per line

--- a/buku.1
+++ b/buku.1
@@ -10,7 +10,7 @@ is a command-line utility to store, tag, search and organize bookmarks.
 .B Features
 .PP
   * Store bookmarks with auto-fetched title, tags and description
-  * Auto-import from Firefox, Google Chrome and Chromium
+  * Auto-import from Firefox, Waterfox, Google Chrome and Chromium
   * Open bookmarks and search results in browser
   * Shorten, expand URLs, browse cached page from Wayback Machine
   * Text editor integration
@@ -187,7 +187,7 @@ Decrypt (unlock) the DB file with
 .SH POWER OPTIONS
 .TP
 .BI \--ai
-Auto-import bookmarks from Firefox, Google Chrome and Chromium browsers.
+Auto-import bookmarks from Firefox, Waterfox, Google Chrome and Chromium browsers.
 .TP
 .BI \-e " " \--export " file"
 Export bookmarks to Firefox bookmarks formatted HTML. Works with all search options. Markdown is used if


### PR DESCRIPTION
Waterfox ( https://www.waterfoxproject.org ) lives in a different folder, but has the same file format as Firefox.

Works fine on Linux but has not been tested on Windows/Darwin.
