### PR TITLE
new: user: open in new tab

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -57,6 +57,7 @@ Following are available os env config available for bukuserver.
 | URL_RENDER_MODE | url render mode | `full` or `netloc` [default: `full`] |
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
 | DISABLE_FAVICON | disable favicon | boolean [default: `false`] |
+| OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
 
 Note: `BUKUSERVER_` is the common prefix.
 

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -100,7 +100,10 @@ class BookmarkModelView(BaseModelView):
             res = netloc_tmpl.format(
                 'http://www.google.com/s2/favicons?domain=', netloc)
         title = model.title if model.title else '&lt;EMPTY TITLE&gt;'
-        if is_scheme_valid:
+        open_in_new_tab = current_app.config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False)
+        if is_scheme_valid and open_in_new_tab:
+            res += '<a href="{0.url}" target="_blank">{1}</a>'.format(model, title)
+        elif is_scheme_valid and not open_in_new_tab:
             res += '<a href="{0.url}">{1}</a>'.format(model, title)
         else:
             res += title


### PR DESCRIPTION
fix #394 

this is will not change default behaviour because user can open new tab by ctrl+click, middle click, or other way. but this will give user option to enable this as default.