### PR TITLE
fix: test: ignore too many ancestor error

### DIFF
--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -64,7 +64,7 @@ def setup():
         os.remove(TEST_TEMP_DBFILE_PATH)
 
 
-class PrettySafeLoader(yaml.SafeLoader):
+class PrettySafeLoader(yaml.SafeLoader):   # pylint: disable=too-many-ancestors
     def construct_python_tuple(self, node):
         return tuple(self.construct_sequence(node))
 


### PR DESCRIPTION
follow up on #405 & #407

if @stkw0 can verify it, @jarun, you can just merge it even if labels haven't been changed

other alternative can be seen here https://stackoverflow.com/questions/22834392/understanding-too-many-ancestors-from-pylint

but i choose this one as this is only occur once