### PR TITLE
feat(docker): add Dockerfile to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:alpine
+
+MAINTAINER Ameya Shenoy "shenoy.ameya@gmail.com"
+
+
+COPY . /Buku
+RUN set -ex \
+  && apk add --no-cache \
+    git \
+    gcc \
+    openssl-dev \
+    musl-dev \
+    libffi-dev \
+  && pip install -U --no-cache-dir \
+    pip \
+  && cd Buku \
+  && pip install --no-cache-dir .[server]
+
+ENTRYPOINT FLASK_ENV=production FLASK_APP=/Buku/bukuserver/server.py flask run --host 0.0.0.0 --port 5001
+EXPOSE 5001
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:alpine
 
 MAINTAINER Ameya Shenoy "shenoy.ameya@gmail.com"
 
-
-COPY . /Buku
 RUN set -ex \
   && apk add --no-cache \
     git \
@@ -13,10 +11,12 @@ RUN set -ex \
     libffi-dev \
   && pip install -U --no-cache-dir \
     pip \
-    gunicorn \
-  && cd Buku \
+    gunicorn
+
+COPY . /Buku
+RUN cd Buku \
   && pip install --no-cache-dir .[server]
 
-ENTRYPOINT gunicorn --bind 0.0.0.0:5001 "Buku.bukuserver.server:create_app()"
+ENTRYPOINT gunicorn --bind 0.0.0.0:5001 --log-level DEBUG "Buku.bukuserver.server:create_app()"
 EXPOSE 5001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN set -ex \
     libffi-dev \
   && pip install -U --no-cache-dir \
     pip \
+    gunicorn \
   && cd Buku \
   && pip install --no-cache-dir .[server]
 
-ENTRYPOINT FLASK_ENV=production FLASK_APP=/Buku/bukuserver/server.py flask run --host 0.0.0.0 --port 5001
+ENTRYPOINT gunicorn --bind 0.0.0.0:5001 "Buku.bukuserver.server:create_app()"
 EXPOSE 5001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,20 @@ FROM python:alpine
 
 MAINTAINER Ameya Shenoy "shenoy.ameya@gmail.com"
 
+COPY . /Buku
+
 RUN set -ex \
-  && apk add --no-cache \
-    git \
+  && apk add --no-cache --virtual .build-deps \
     gcc \
     openssl-dev \
     musl-dev \
     libffi-dev \
   && pip install -U --no-cache-dir \
     pip \
-    gunicorn
+    gunicorn \
+    Buku[server] \
+  && apk del .build-deps
 
-COPY . /Buku
-RUN cd Buku \
-  && pip install --no-cache-dir .[server]
-
-ENTRYPOINT gunicorn --bind 0.0.0.0:5001 --log-level DEBUG "Buku.bukuserver.server:create_app()"
+ENTRYPOINT gunicorn --bind 0.0.0.0:5001 "Buku.bukuserver.server:create_app()"
 EXPOSE 5001
 

--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -6,6 +6,7 @@
   - [Dependencies](#dependencies)
   - [From PyPi](#from-pypi)
   - [From source](#from-source)
+  - [Using Docker](#using-docker)
 - [Webserver options](#webserver-options)
 - [Configuration](#configuration)
 - [Screenshots](#screenshots)
@@ -35,6 +36,26 @@ $ git clone https://github.com/jarun/Buku
 $ cd Buku
 $ pip3 install .[server]
 ```
+
+#### Using Docker
+
+To build the image execute the command from the root directory of the project:
+
+```sh
+docker build -t bukuserver .
+```
+
+To run the generated image.
+
+```sh
+docker run -it --rm -v ~/.local/share/buku:/root/.local/share/buku -p 5001:5001 bukuserver
+```
+
+All the data generated will be stored in the `~/.local/share/buku` directory.
+Feel free to change it to the full path of the location you want to store the
+database.
+
+Visit `127.0.0.1:5001` in your browser to access your bookmarks.
 
 ### Webserver options
 


### PR DESCRIPTION
Also added related docs. It is worth mentioning that at this point the
server used inside the docker container is the default Flask server,
which is not production ready.

Edit: modified Dockerfile to serve requests with `gunicorn`

Linked to #410 