### PR TITLE
create setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[options.extras_require]
+tests = tests_require_server_require
+server = server_require
+packaging = twine>=1.11.0
+
+[options.entry_points]
+console_scripts =
+   buku = buku:main
+   bukuserver = bukuserver.server:cli

--- a/setup.py
+++ b/setup.py
@@ -79,14 +79,6 @@ setup(
     ],
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    entry_points={
-        'console_scripts': ['buku=buku:main', 'bukuserver=bukuserver.server:cli']
-    },
-    extras_require={
-        'tests': tests_require + server_require,
-        'server': server_require,
-        'packaging': ['twine>=1.11.0']
-    },
     test_suite='tests',
     tests_require=tests_require,
     keywords='cli bookmarks tag utility',


### PR DESCRIPTION
In Gentoo we where trying to find a way to enable/disable the installation of buku web server and I was suggested to move that to setup.cfg (I didn't know what setup.cfg was before that). This patch tries to move bukuserver related things to setup.cfg but I'm not completely sure this is the right way. 
See also  https://github.com/gentoo/gentoo/pull/10332#discussion_r308104532 for the related discussion. 