### PR TITLE
fix tag model view

### DIFF
--- a/bukuserver/filters.py
+++ b/bukuserver/filters.py
@@ -24,7 +24,7 @@ def greater_func(query, value, index):
 
 
 def smaller_func(query, value, index):
-    return filter(lambda x: x[index] > value, query)
+    return filter(lambda x: x[index] < value, query)
 
 
 def in_list_func(query, value, index):

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -406,7 +406,7 @@ class TagModelView(BaseModelView):
             page_size: int = None) -> Tuple[int, List[SimpleNamespace]]:
         bukudb = self.bukudb
         tags = bukudb.get_tag_all()[1]
-        tags = tags.items()
+        tags = sorted(tags.items())
         tags = self._apply_filters(tags, filters)
         sort_field_dict = {'usage_count': 1, 'name': 0}
         if sort_field in sort_field_dict:

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -2,7 +2,7 @@
 from argparse import Namespace
 from collections import Counter
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 import itertools
 import logging
@@ -396,16 +396,22 @@ class TagModelView(BaseModelView):
     def scaffold_list_form(self, widget=None, validators=None):
         pass
 
-    def get_list(self, page, sort_field, sort_desc, search, filters, page_size=None):
+    def get_list(
+            self,
+            page: int,
+            sort_field: str,
+            sort_desc: bool,
+            search: Optional[Any],
+            filters: List[Tuple[int, str, str]],
+            page_size: int = None) -> Tuple[int, List[SimpleNamespace]]:
         bukudb = self.bukudb
         tags = bukudb.get_tag_all()[1]
-        tags = dict(tags.items())
+        tags = tags.items()
         tags = self._apply_filters(tags, filters)
-        if sort_field == 'usage_count':
-            tags = sorted(tags, key=lambda x: x[1], reverse=sort_desc)
-        elif sort_field == 'name':
-            tags = sorted(tags, key=lambda x: x[0], reverse=sort_desc)
-        tags = list(tags)
+        sort_field_dict = {'usage_count': 1, 'name': 0}
+        if sort_field in sort_field_dict:
+            tags = list(sorted(
+                tags, key=lambda x: x[sort_field_dict[sort_field]], reverse=sort_desc))
         count = len(tags)
         if page_size and tags:
             tags = list(chunks(tags, page_size))[page]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -27,7 +27,6 @@ def test_bookmark_model_view(tmp_path, client, disable_favicon):
     model = Namespace(
         description='randomdesc', id=1, tags='tags1',
         title='Example Domain', url='http://example.com')
-    #  __import__('pdb').set_trace()
     current_app.config['BUKUSERVER_DISABLE_FAVICON'] = disable_favicon
     img_html = ''
     if not disable_favicon:
@@ -65,7 +64,7 @@ def test_tag_model_view_get_list_empty_db(tmv_instance):
         None, False, [], (3, [
             SimpleNamespace(name='t1', usage_count=1),
             SimpleNamespace(name='t2', usage_count=2),
-            SimpleNamespace(name='t3', usage_count=3)
+            SimpleNamespace(name='t3', usage_count=3),
         ])
     ],
     [
@@ -77,7 +76,7 @@ def test_tag_model_view_get_list_empty_db(tmv_instance):
         'name', False, [], (3, [
             SimpleNamespace(name='t1', usage_count=1),
             SimpleNamespace(name='t2', usage_count=2),
-            SimpleNamespace(name='t3', usage_count=3)
+            SimpleNamespace(name='t3', usage_count=3),
         ])
     ],
     [


### PR DESCRIPTION
related #424

this actually only restore the change from 6bfe5050bc81f185b0c38198a080077a788fcfdb 

on that discussion i offer to change it to dict but looking at the filter method, it require to change flask_admin's `_filter` method which make it more complicated.

https://github.com/jarun/Buku/blob/467d865e420a11c5a5f858a83f38bd9d5b3abd82/bukuserver/views.py#L355

so it is keep as list. 

minor change is a default sort for that list, because dict.items in python 3.5 will return result in different order


also added type hint and test for `get_list` method

e: just found about the bug source on model view. fix added to pr