### PR TITLE
reverse proxy

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -110,10 +110,11 @@ Following are available os env config available for bukuserver.
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
 | DISABLE_FAVICON | disable favicon | boolean [default: `false`] |
 | OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
+| REVERSE_PROXY_PATH | reverse proxy path | string |
 
 Note: `BUKUSERVER_` is the common prefix.
 
-Note: if input is invalid, the default value will be used
+Note: if input is invalid, the default value will be used if defined
 
 e.g. to set bukuserver to show 100 item per page run the following command
 
@@ -127,6 +128,10 @@ $ SET BUKUSERVER_PER_PAGE=100
 # in dockerfile
 ENV BUKUSERVER_PER_PAGE=100
 ```
+
+Note: the value for BUKUSERVER_REVERSE_PROXY_PATH 
+is recommended to include preceding slash and not have trailing slash
+(i.e. use `/foo` not `/foo/`)
 
 ### Screenshots
 

--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -8,6 +8,7 @@ Flask-Admin>=1.5.1
 Flask-API>=0.6.9
 Flask-Bootstrap>=3.3.7.1
 flask-paginate>=0.5.1
+flask-reverse-proxy-fix>=0.2.1
 Flask-WTF>=0.14.2
 Flask>=1.0.2
 idna>=2.5

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -28,6 +28,10 @@ from flask import (  # type: ignore
     request,
     url_for,
 )
+try:
+    from flask_reverse_proxy_fix.middleware import ReverseProxyPrefixFix
+except ImportError:
+    ReverseProxyPrefixFix = None
 
 try:
     from . import response, forms, views
@@ -228,6 +232,9 @@ def create_app(db_file=None):
     app.config['BUKUSERVER_OPEN_IN_NEW_TAB'] = \
         False if open_in_new_tab.lower() in ['false', '0'] else bool(open_in_new_tab)
     app.config['BUKUSERVER_DB_FILE'] = os.getenv('BUKUSERVER_DB_FILE') or db_file
+    if ReverseProxyPrefixFix is not None:
+        app.config['REVERSE_PROXY_PATH'] = os.getenv('BUKUSERVER_REVERSE_PROXY_PATH')
+        ReverseProxyPrefixFix(app)
     bukudb = BukuDb(dbfile=app.config['BUKUSERVER_DB_FILE'])
     app.app_context().push()
     setattr(flask.g, 'bukudb', bukudb)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ server_require = [
     'Flask-API>=0.6.9',
     'Flask-Bootstrap>=3.3.7.1',
     'flask-paginate>=0.5.1',
+    'flask-reverse-proxy-fix>=0.2.1',
     'Flask-WTF>=0.14.2',
     'Flask>=1.0.2',
     'idna>=2.5',


### PR DESCRIPTION
related #415

e: to use it

- install flask-reverse-proxy-fix `pip install flask-reverse-proxy-fix`
- set `BUKUSERVER_REVERSE_PROXY_PATH`
  - note from flask-reverse-proxy-fix: The prefix value SHOULD include a preceding slash, it SHOULD NOT include a trailing slash (i.e. use /foo not /foo/).