### PR TITLE
Org tag support

### DIFF
--- a/buku
+++ b/buku
@@ -3039,16 +3039,18 @@ def import_org(filepath, newtag):
                     # Parse url
                     url = line[url_start_delim + 2:index]
                     # Parse Tags
-                    tags = DELIM.join(get_org_tags(line[(index + 4 + title_end_delim):]))
+                    tags = list(dict.fromkeys(get_org_tags(line[(index + 4 + title_end_delim):])))
+                    tags_string = DELIM.join(tags)
 
                     if is_nongeneric_url(url):
                         continue
 
                     if newtag:
-                        tags = (newtag + DELIM) + tags
+                        if newtag.lower() not in tags:
+                            tags_string = (newtag + DELIM) + tags_string
 
                     yield (
-                        url, title, delim_wrap(tags)
+                        url, title, delim_wrap(tags_string)
                         if newtag else None, None, 0, True
                     )
 

--- a/buku
+++ b/buku
@@ -3008,16 +3008,16 @@ def import_org(filepath, newtag):
         """
         tag_list_raw = [i for i in re.split(r'(?<!\:)\:', tag_string) if i]
         tag_list_cleaned = []
-        for i in range(len(tag_list_raw)):
-            if tag_list_raw[i].startswith(":"):
+        for i, tag in enumerate(tag_list_raw):
+            if tag.startswith(":"):
                 if tag_list_raw[i-1] == ' ':
-                    tag_list_cleaned.append(tag_list_raw[i].strip())
+                    tag_list_cleaned.append(tag.strip())
                 else:
-                    new_item = tag_list_cleaned[-1] + tag_list_raw[i]
+                    new_item = tag_list_cleaned[-1] + tag
                     del tag_list_cleaned[-1]
                     tag_list_cleaned.append(new_item.strip())
-            elif tag_list_raw[i] != ' ':
-                tag_list_cleaned.append(tag_list_raw[i].strip())
+            elif tag != ' ':
+                tag_list_cleaned.append(tag.strip())
         return tag_list_cleaned
 
     with open(filepath, mode='r', encoding='utf-8') as infp:

--- a/buku
+++ b/buku
@@ -39,6 +39,7 @@ import threading
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 import webbrowser
+import ipdb
 try:
     import readline
 except ImportError:
@@ -2828,9 +2829,15 @@ def convert_bookmark_set(
     elif export_type == 'org':
         for row in resultset:
             if not row[2]:
-                out += '* [[{}][Untitled]]\n'.format(row[1])
+                out += '* [[{}][Untitled]]'.format(row[1])
             else:
-                out += '* [[{}][{}]]\n'.format(row[1], row[2])
+                out += '* [[{}][{}]]'.format(row[1], row[2])
+
+            if row[3] != DELIM:
+                out += ' :{}:\n'.format(':'.join(row[3].split(DELIM)[1:-1]))
+            else:
+                out += '\n'
+                
             count += 1
     elif export_type == 'html':
         timestamp = str(int(time.time()))
@@ -2978,8 +2985,9 @@ def import_org(filepath, newtag):
     tuple
         Parsed result.
     """
+    
     with open(filepath, mode='r', encoding='utf-8') as infp:
-        # Supported Markdown format: * [[url][title]]
+        # Supported Markdown format: * [[url][title]] :tags:
         # Find position of url end, title start delimiter combo
         for line in infp:
             index = line.find('][')
@@ -2994,11 +3002,17 @@ def import_org(filepath, newtag):
                     title = line[index + 2: index + 2 + title_end_delim]
                     # Parse url
                     url = line[url_start_delim + 2:index]
+                    # Parse Tags
+                    tags = DELIM.join(line[(index + 2 + title_end_delim):].split(':')[1:-1])
+
                     if is_nongeneric_url(url):
                         continue
 
+                    if newtag:
+                        tags = (newtag + DELIM) + tags
+
                     yield (
-                        url, title, delim_wrap(newtag)
+                        url, title, delim_wrap(tags)
                         if newtag else None, None, 0, True
                     )
 
@@ -4859,7 +4873,7 @@ POSITIONAL ARGUMENTS:
                          export Markdown, if file ends with '.md'
                          format: [title](url), 1 entry per line
                          export Orgfile, if file ends with '.org'
-                         format: *[[url][title]], 1 entry per line
+                         format: *[[url][title]] :tags:, 1 entry per line
                          export buku DB, if file ends with '.db'
                          combines with search results, if opted
     -i, --import file    import bookmarks based on file extension

--- a/buku
+++ b/buku
@@ -2833,7 +2833,12 @@ def convert_bookmark_set(
                 out += '* [[{}][{}]]'.format(row[1], row[2])
 
             if row[3] != DELIM:
-                out += ' :{}:\n'.format(':'.join(row[3].split(DELIM)[1:-1]))
+                # add additional whitespaces for tags that end or start with a colon
+                tag_string = row[3].replace(',:', ', ,:').replace(':,', ':, ,')
+                buku_tags = tag_string.split(DELIM)[1:-1]
+                # if colons are inside a tag, add one additional colon
+                buku_tags = [re.sub(r'(?<=[\w,\:]):(?=\w)', '::', tag) for tag in buku_tags]
+                out += ' :{}:\n'.format(':'.join(buku_tags))
             else:
                 out += '\n'
 
@@ -2984,6 +2989,38 @@ def import_org(filepath, newtag):
     tuple
         Parsed result.
     """
+    def get_org_tags(tag_string):
+        """Extracts tags from Org
+
+        Parameters
+        ----------
+        tag_string: str
+             string of tags in Org-format
+
+        Syntax: Org splits tags with colons. If colons are part of a buku-tag, this is indicated by using
+                multiple colons in org. If a buku-tag starts or ends with a colon, this is indicated by a
+                preceding or trailing whitespace
+
+        Returns
+        -------
+        list
+            List of tags
+        """
+        tag_list_raw = [i for i in re.split(r'(?<!\:)\:', tag_string) if i]
+        tag_list_cleaned = []
+        for i in range(len(tag_list_raw)):
+            if tag_list_raw[i] == ' ':
+                continue
+            elif tag_list_raw[i].startswith(":"):
+                if tag_list_raw[i-1] == ' ':
+                    tag_list_cleaned.append(tag_list_raw[i].strip())
+                else:
+                    new_item = tag_list_cleaned[-1] + tag_list_raw[i]
+                    del tag_list_cleaned[-1]
+                    tag_list_cleaned.append(new_item.strip())
+            else:
+                tag_list_cleaned.append(tag_list_raw[i].strip())
+        return tag_list_cleaned
 
     with open(filepath, mode='r', encoding='utf-8') as infp:
         # Supported Markdown format: * [[url][title]] :tags:
@@ -3002,7 +3039,7 @@ def import_org(filepath, newtag):
                     # Parse url
                     url = line[url_start_delim + 2:index]
                     # Parse Tags
-                    tags = DELIM.join(line[(index + 2 + title_end_delim):].split(':')[1:-1])
+                    tags = DELIM.join(get_org_tags(line[(index + 4 + title_end_delim):]))
 
                     if is_nongeneric_url(url):
                         continue

--- a/buku
+++ b/buku
@@ -3037,7 +3037,7 @@ def import_org(filepath, newtag):
                     # Parse url
                     url = line[url_start_delim + 2:index]
                     # Parse Tags
-                    tags = list(dict.fromkeys(get_org_tags(line[(index + 4 + title_end_delim):])))
+                    tags = list(collections.OrderedDict.fromkeys(get_org_tags(line[(index + 4 + title_end_delim):])))
                     tags_string = DELIM.join(tags)
 
                     if is_nongeneric_url(url):

--- a/buku
+++ b/buku
@@ -2836,7 +2836,7 @@ def convert_bookmark_set(
                 out += ' :{}:\n'.format(':'.join(row[3].split(DELIM)[1:-1]))
             else:
                 out += '\n'
-                
+
             count += 1
     elif export_type == 'html':
         timestamp = str(int(time.time()))
@@ -2984,7 +2984,7 @@ def import_org(filepath, newtag):
     tuple
         Parsed result.
     """
-    
+
     with open(filepath, mode='r', encoding='utf-8') as infp:
         # Supported Markdown format: * [[url][title]] :tags:
         # Find position of url end, title start delimiter combo

--- a/buku
+++ b/buku
@@ -39,7 +39,6 @@ import threading
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 import webbrowser
-import ipdb
 try:
     import readline
 except ImportError:

--- a/buku
+++ b/buku
@@ -3009,16 +3009,14 @@ def import_org(filepath, newtag):
         tag_list_raw = [i for i in re.split(r'(?<!\:)\:', tag_string) if i]
         tag_list_cleaned = []
         for i in range(len(tag_list_raw)):
-            if tag_list_raw[i] == ' ':
-                continue
-            elif tag_list_raw[i].startswith(":"):
+            if tag_list_raw[i].startswith(":"):
                 if tag_list_raw[i-1] == ' ':
                     tag_list_cleaned.append(tag_list_raw[i].strip())
                 else:
                     new_item = tag_list_cleaned[-1] + tag_list_raw[i]
                     del tag_list_cleaned[-1]
                     tag_list_cleaned.append(new_item.strip())
-            else:
+            elif tag_list_raw[i] != ' ':
                 tag_list_cleaned.append(tag_list_raw[i].strip())
         return tag_list_cleaned
 

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -605,13 +605,13 @@ def test_import_md(tmpdir, newtag, exp_res):
     'newtag, exp_res',
     [
         (None, ('http://example.com', 'text1', None, None, 0, True)),
-        ('tag2', ('http://example.com', 'text1', ',tag2,tag1,', None, 0, True)),
+        ('tag0', ('http://example.com', 'text1', ',tag0,tag1,:tag2,tag:3,tag4:,tag::5,tag:6:,', None, 0, True)),
     ]
 )
 def test_import_org(tmpdir, newtag, exp_res):
     from buku import import_org
     p = tmpdir.mkdir("importorg").join("test.org")
-    p.write("[[http://example.com][text1]] :tag1:")
+    p.write("[[http://example.com][text1]] :tag1: ::tag2:tag::3:tag4:: :tag:::5:tag::6:: :")
     res = list(import_org(p.strpath, newtag))
     assert res[0] == exp_res
 

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -601,6 +601,20 @@ def test_import_md(tmpdir, newtag, exp_res):
     res = list(import_md(p.strpath, newtag))
     assert res[0] == exp_res
 
+@pytest.mark.parametrize(
+    'newtag, exp_res',
+    [
+        (None, ('http://example.com', 'text1', None, None, 0, True)),
+        ('tag2', ('http://example.com', 'text1', ',tag2,tag1,', None, 0, True)),
+    ]
+)
+def test_import_org(tmpdir, newtag, exp_res):
+    from buku import import_org
+    p = tmpdir.mkdir("importorg").join("test.org")
+    p.write("[[http://example.com][text1]] :tag1:")
+    res = list(import_org(p.strpath, newtag))
+    assert res[0] == exp_res
+
 
 @pytest.mark.parametrize(
     'html_text, exp_res',


### PR DESCRIPTION
Description: This PR adds support for tags for Org-Mode import/export. According to Org-Mode syntax, tags are added at the end of a line as a list of colon separated keywords:
* [[url][title]] :tag1:tag2:

No new dependencies were added, and I have tested import and export of bookmarks with and without tags without problems.

I only changed the code for Org import/export, and the displayed help message, so I don't expect any side effects.