### PR TITLE
Feature/windows

### DIFF
--- a/buku
+++ b/buku
@@ -39,15 +39,19 @@ import threading
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 import webbrowser
-try:
-    import readline
-except ImportError:
-    import pyreadline as readline  # type: ignore
-from bs4 import BeautifulSoup
 import certifi
 import urllib3
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url, make_headers
+from bs4 import BeautifulSoup
+READLINE_ERROR = ImportError
+# note: replace this when python3.5 is not supported
+if sys.version_info.major == 3 and sys.version_info.minor > 5:
+    READLINE_ERROR = (ImportError, ModuleNotFoundError)  # type: ignore
+try:
+    import readline
+except READLINE_ERROR:
+    import pyreadline as readline  # type: ignore
 try:
     from mypy_extensions import TypedDict
 except ImportError:

--- a/buku
+++ b/buku
@@ -44,13 +44,11 @@ import urllib3
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url, make_headers
 from bs4 import BeautifulSoup
-READLINE_ERROR = ImportError
-# note: replace this when python3.5 is not supported
-if sys.version_info.major == 3 and sys.version_info.minor > 5:
-    READLINE_ERROR = (ImportError, ModuleNotFoundError)  # type: ignore
+# note catch ModuleNotFoundError instead Exception
+# when python3.5 not supported
 try:
     import readline
-except READLINE_ERROR:
+except Exception:
     import pyreadline as readline  # type: ignore
 try:
     from mypy_extensions import TypedDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cryptography>=1.2.3
 html5lib>=1.0.1
 setuptools
 urllib3>=1.23
+pyreadline; sys_platform == 'windows'


### PR DESCRIPTION
- use general Exception instead ImportError+ModuleNotFoundError, imo more expected result than adding ModuleNotFoundError to python3.5
- package requirement is taken from https://www.python.org/dev/peps/pep-0508/

i put do-not-merge label because i don't have windows dev to test it. the pr is actually finished except if there is another commit needed to fix problem from windows tester