### PR TITLE
Bugfix/travis

### DIFF
--- a/buku
+++ b/buku
@@ -1474,6 +1474,11 @@ class BukuDb:
             True if record should not be committed to the DB,
             leaving commit responsibility to caller. Default is False.
 
+        Raises
+        ------
+        TypeError
+            If any of index, low, or high variable is not integer.
+
         Returns
         -------
         bool

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -936,16 +936,14 @@ def test_delete_rec_on_non_interger(index, low, high, is_range):
 
     for bookmark in TEST_BOOKMARKS:
         bdb.add_rec(*bookmark)
-    db_len = len(TEST_BOOKMARKS)
 
     if is_range and not (isinstance(low, int) and isinstance(high, int)):
         with pytest.raises(TypeError):
             bdb.delete_rec(index=index, low=low, high=high, is_range=is_range)
         return
     if not is_range and not isinstance(index, int):
-        res = bdb.delete_rec(index=index, low=low, high=high, is_range=is_range)
-        assert not res
-        assert len(bdb.get_rec_all()) == db_len
+        with pytest.raises(TypeError):
+            bdb.delete_rec(index=index, low=low, high=high, is_range=is_range)
     else:
         assert bdb.delete_rec(index=index, low=low, high=high, is_range=is_range)
 


### PR DESCRIPTION
fix travis test by change the test when input non integer to index variable

no idea why the error just changed now when executing this line `LOGERR('No matching index %d', index)`

good thing that it is more consistent because now related input variables require integer and will raise error otherwise 

my recommendation is to put an actual type check so the function will depend on that instead other line which caused the same error