### PR TITLE
buku tags to org mode tags

### DIFF
--- a/buku
+++ b/buku
@@ -2819,6 +2819,18 @@ PROMPT KEYS:
 ConverterResult = TypedDict('ConverterResult', {'data': str, 'count': int}) if TypedDict else Dict[str, Any]
 
 
+def convert_tags_to_org_mode_tags(tags: str) -> str:
+    """convert buku tags to org-mode compatible tags."""
+    if tags != DELIM:
+        buku_tags = tags.split(DELIM)[1:-1]
+        buku_tags = [re.sub(r'[^a-zA-Z0-9_@]', ' ', tag) for tag in buku_tags]
+        buku_tags = [re.sub(r'\s+', ' ', tag) for tag in buku_tags]
+        buku_tags = list(sorted(set([x.replace(' ', '_') for x in buku_tags]), reverse=False))
+        if buku_tags:
+            return ' :{}:\n'.format(':'.join(buku_tags))
+    return '\n'
+
+
 def convert_bookmark_set(
         bookmark_set: List[BookmarkVar],
         export_type: str) -> ConverterResult:  # type: ignore
@@ -2858,17 +2870,7 @@ def convert_bookmark_set(
                 out += '* [[{}][Untitled]]'.format(row[1])
             else:
                 out += '* [[{}][{}]]'.format(row[1], row[2])
-
-            if row[3] != DELIM:
-                # add additional whitespaces for tags that end or start with a colon
-                tag_string = row[3].replace(',:', ', ,:').replace(':,', ':, ,')
-                buku_tags = tag_string.split(DELIM)[1:-1]
-                # if colons are inside a tag, add one additional colon
-                buku_tags = [re.sub(r'(?<=[\w,\:]):(?=\w)', '::', tag) for tag in buku_tags]
-                out += ' :{}:\n'.format(':'.join(buku_tags))
-            else:
-                out += '\n'
-
+            out += convert_tags_to_org_mode_tags(row[3])
             count += 1
     elif export_type == 'html':
         timestamp = str(int(time.time()))

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -779,6 +779,7 @@ def test_convert_bookmark_set(export_type, exp_res, monkeypatch):
     [',word1:word2,', ' :word1_word2:\n'],
     [',##tag##,', ' :_tag_:\n'],
     [',##tag##,!!tag!!,', ' :_tag_:\n'],
+    [',home / personal,', ' :home_personal:\n'],
 ])
 def test_convert_tags_to_org_mode_tags(tags, data):
     from buku import convert_tags_to_org_mode_tags

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -770,3 +770,17 @@ def test_convert_bookmark_set(export_type, exp_res, monkeypatch):
         res = convert_bookmark_set(bms, export_type=export_type)
         assert res['count'] == 3
         assert exp_res == res['data']
+
+
+@pytest.mark.parametrize('tags,data', [
+    [',', '\n'],
+    [',tag1,tag2,', ' :tag1:tag2:\n'],
+    [',word1 word2,', ' :word1_word2:\n'],
+    [',word1:word2,', ' :word1_word2:\n'],
+    [',##tag##,', ' :_tag_:\n'],
+    [',##tag##,!!tag!!,', ' :_tag_:\n'],
+])
+def test_convert_tags_to_org_mode_tags(tags, data):
+    from buku import convert_tags_to_org_mode_tags
+    res = convert_tags_to_org_mode_tags(tags)
+    assert res == data


### PR DESCRIPTION
### Description

change buku tags to org mode tags convertion

related issue #469

### Design notes

old rules:

- add additional whitespaces for tags that end or start with a colon
- if colons are inside a tag, add one additional colon

new logic:

1. any character which don't match `[a-zA-Z0-9_@]` will replaced with space character
2. multiple whitespaces will be replaced with underscore character
3. only unique tags will be returned in ascending order

### Side effects

it will break logic from previous version.

### Test cases

only simple test case and a single tag based on related related issue
