### PR TITLE
Fix BukuCrypt.encrypt_file

### DIFF
--- a/buku
+++ b/buku
@@ -226,9 +226,11 @@ class BukuCrypt:
                     if len(chunk) == 0:
                         break
                     if len(chunk) % 16 != 0:
-                        chunk = '%s%s' % (chunk, ' ' * (16 - len(chunk) % 16))
+                        chunk = b'%b%b' % (chunk, b' ' * (16 - len(chunk) % 16))
 
-                    outfp.write(encryptor.update(chunk) + encryptor.finalize())
+                    outfp.write(encryptor.update(chunk))
+
+                outfp.write(encryptor.finalize())
 
             os.remove(dbfile)
             print('File encrypted')


### PR DESCRIPTION
Two bugs:

- When padding data, `chunk`'s type was changed from bytes to str.
- `encryptor.finalize` was called in a loop, causing `AlreadyFinalized` whenever there are more than one chunk.

To reproduce old bugs:

Use a file larger than `CHUNKSIZE` (512KiB):

```console
$ ln buku buku.py
$ dd if=/dev/zero bs=1024 count=513 of=data
$ python3 -c 'import buku; buku.BukuCrypt.encrypt_file(8, "data")'
Password:
Password:
Context was already finalized.
```

Similarly, to reproduce the padding bug, just create a file that's not a multiple of 16 bytes. I think this buggy code path wasn't ever triggered due to SQLite databases always being full blocks.