### PR TITLE
update print_rec and delete_rec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    # -   id: trailing-whitespace
+    # -   id: end-of-file-fixer
+    # -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/PyCQA/pylint/
+    rev: '2.6'
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: ['--rcfile', 'tests/.pylintrc']
+        # exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/

--- a/buku
+++ b/buku
@@ -1722,7 +1722,6 @@ class BukuDb:
         is_range : bool, optional
             A range is passed using low and high arguments.
             An index is ignored if is_range is True.
-            Default is False.
 
         Returns
         -------

--- a/buku
+++ b/buku
@@ -1460,17 +1460,17 @@ class BukuDb:
 
     def delete_rec(
             self,
-            index: int,
+            index: int = None,
             low: int = 0,
             high: int = 0,
             is_range: bool = False,
             delay_commit: bool = False
     ) -> bool:
-        """Delete a single record or remove the table if index is None.
+        """Delete a single record or remove the table if index is 0.
 
         Parameters
         ----------
-        index : int
+        index : int, optional
             DB index of deleted entry.
         low : int, optional
             Actual lower index of range.
@@ -1478,8 +1478,7 @@ class BukuDb:
             Actual higher index of range.
         is_range : bool, optional
             A range is passed using low and high arguments.
-            An index is ignored if is_range is True (use dummy index).
-            Default is False.
+            An index is ignored if is_range is True.
         delay_commit : bool, optional
             True if record should not be committed to the DB,
             leaving commit responsibility to caller. Default is False.
@@ -1493,7 +1492,54 @@ class BukuDb:
         -------
         bool
             True on success, False on failure.
+
+        Examples
+        --------
+        >>> from tempfile import NamedTemporaryFile
+        >>> import buku
+        >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # single record database
+        >>> sdb.add_rec('https://example.com')
+        >>> sdb.delete_rec(1)
+        Index 1 deleted
+        True
+
+        Delete record with default range.
+
+        >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
+        >>> sdb.add_rec('https://example.com')
+        >>> sdb.delete_rec(is_range=True)
+        Remove ALL bookmarks? (y/n): y
+        All bookmarks deleted
+        True
+
+        Running the function without any parameter will raise TypeError.
+
+        >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
+        >>> sdb.add_rec('https://example.com')
+        >>> sdb.delete_rec()
+        TypeError: index, low, or high variable is not integer
+
+        Negative number on `high` and `low` paramaters when is_range is True
+        will log error and return False
+
+        >>> edb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
+        >>> edb.delete_rec(low=-1, high=-1, is_range=True)
+        Negative range boundary
+        False
+
+        Remove the table
+
+        >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
+        >>> sdb.delete_rec(0)
+        Remove ALL bookmarks? (y/n): y
+        All bookmarks deleted
+        True
         """
+        params = [low, high]
+        if not is_range:
+            params.append(index)
+        if any(map(lambda x: not isinstance(x, int), params)):
+            raise TypeError('index, low, or high variable is not integer')
 
         if is_range:  # Delete a range of indices
             if low < 0 or high < 0:

--- a/buku
+++ b/buku
@@ -1663,6 +1663,8 @@ class BukuDb:
 
         A negative index behaves like tail, if title is blank show "Untitled".
 
+        Empty database check will run when `index` < 0 and `is_range` is False.
+
         Parameters
         -----------
         index : int, optional
@@ -1673,16 +1675,48 @@ class BukuDb:
             Actual higher index of range.
         is_range : bool, optional
             A range is passed using low and high arguments.
-            An index is ignored if is_range is True (use dummy index).
+            An index is ignored if is_range is True.
             Default is False.
 
         Returns
         -------
         bool
             True on success, False on failure.
-        """
 
-        if index < 0:
+        Examples
+        --------
+        >>> import buku
+        >>> from tempfile import NamedTemporaryFile
+        >>> edb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # empty database
+        >>> edb.print_rec()
+        0 records
+        True
+
+        Print negative index on empty database will log error and return False
+
+        >>> edb.print_rec(-3)
+        Empty database
+        False
+
+        print non empty database with default argument.
+
+        >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # single record database
+        >>> sdb.add_rec('https://example.com')
+        >>> assert sdb.print_rec()
+        1. Example Domain
+           > https://example.com
+
+        Negative number on `high` and `low` paramaters when is_range is True
+        will log error and return False
+
+        >>> sdb.print_rec(low=-1, high=-1, is_range=True)
+        Negative range boundary
+        False
+        >>> edb.print_rec(low=-1, high=-1, is_range=True)
+        Negative range boundary
+        False
+        """
+        if not is_range and index < 0:
             # Show the last n records
             _id = self.get_max_id()
             if _id == -1:

--- a/buku
+++ b/buku
@@ -1499,6 +1499,7 @@ class BukuDb:
         >>> import buku
         >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # single record database
         >>> sdb.add_rec('https://example.com')
+        1
         >>> sdb.delete_rec(1)
         Index 1 deleted
         True
@@ -1507,7 +1508,8 @@ class BukuDb:
 
         >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
         >>> sdb.add_rec('https://example.com')
-        >>> sdb.delete_rec(is_range=True)
+        1
+        >>> sdb.delete_rec(is_range=True)  # doctest: +SKIP
         Remove ALL bookmarks? (y/n): y
         All bookmarks deleted
         True
@@ -1516,7 +1518,10 @@ class BukuDb:
 
         >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
         >>> sdb.add_rec('https://example.com')
+        1
         >>> sdb.delete_rec()
+        Traceback (most recent call last):
+        ...
         TypeError: index, low, or high variable is not integer
 
         Negative number on `high` and `low` paramaters when is_range is True
@@ -1524,13 +1529,12 @@ class BukuDb:
 
         >>> edb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
         >>> edb.delete_rec(low=-1, high=-1, is_range=True)
-        Negative range boundary
         False
 
         Remove the table
 
         >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)
-        >>> sdb.delete_rec(0)
+        >>> sdb.delete_rec(0)  # doctest: +SKIP
         Remove ALL bookmarks? (y/n): y
         All bookmarks deleted
         True
@@ -1734,31 +1738,29 @@ class BukuDb:
         >>> from tempfile import NamedTemporaryFile
         >>> edb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # empty database
         >>> edb.print_rec()
-        0 records
         True
 
         Print negative index on empty database will log error and return False
 
         >>> edb.print_rec(-3)
-        Empty database
         False
 
         print non empty database with default argument.
 
         >>> sdb = buku.BukuDb(dbfile=NamedTemporaryFile().name)  # single record database
         >>> sdb.add_rec('https://example.com')
+        1
         >>> assert sdb.print_rec()
         1. Example Domain
            > https://example.com
+        <BLANKLINE>
 
         Negative number on `high` and `low` paramaters when is_range is True
         will log error and return False
 
         >>> sdb.print_rec(low=-1, high=-1, is_range=True)
-        Negative range boundary
         False
         >>> edb.print_rec(low=-1, high=-1, is_range=True)
-        Negative range boundary
         False
         """
         if not is_range and index < 0:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     'py>=1.5.0',
     'pylint>=1.7.2',
     'pytest-cov',
-    'pytest-vcr>=1.0.2'
+    'pytest-vcr>=1.0.2',
     'pytest>=6.2.1',
     'PyYAML>=4.2b1',
     'setuptools>=41.0.1',

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -25,7 +25,6 @@ import yaml
 from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
-import buku
 from buku import BukuDb, parse_tags, prompt
 
 logging.basicConfig()  # you need to initialize logging, otherwise you will not see anything from vcrpy
@@ -1062,6 +1061,7 @@ def test_delete_rec_on_non_integer(
     setup, tmp_path, monkeypatch, kwargs, exp_res, raise_error
 ):
     """test delete rec on non integer arg."""
+    import buku
     bdb = BukuDb(dbfile=tmp_path / "tmp.db")
 
     for bookmark in TEST_BOOKMARKS:

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1208,6 +1208,8 @@ def test_update_rec_update_all_bookmark(caplog, read_in_retval):
 def test_edit_update_rec_with_invalid_input(get_system_editor_retval, index, exp_res):
     """test method."""
     with mock.patch("buku.get_system_editor", return_value=get_system_editor_retval):
+        import buku
+
         bdb = buku.BukuDb()
         res = bdb.edit_update_rec(index=index)
         assert res == exp_res
@@ -1227,6 +1229,8 @@ def test_browse_by_index(low, high, index, is_range, empty_database):
     """test method."""
     n_low, n_high = (high, low) if low > high else (low, high)
     with mock.patch("buku.browse"):
+        import buku
+
         bdb = buku.BukuDb()
         bdb.delete_rec_all()
         db_len = 0
@@ -1277,6 +1281,8 @@ def test_load_chrome_database(chrome_db, add_pt):
             except RuntimeError:
                 res_yaml = yaml.load(f, Loader=PrettySafeLoader)
     # init
+    import buku
+
     bdb = buku.BukuDb()
     bdb.add_rec = mock.Mock()
     bdb.load_chrome_database(json_file, None, add_pt)
@@ -1322,6 +1328,8 @@ def test_load_firefox_database(firefox_db, add_pt):
             except RuntimeError:
                 res_yaml = yaml.load(f, Loader=PrettySafeLoader)
     # init
+    import buku
+
     bdb = buku.BukuDb()
     bdb.add_rec = mock.Mock()
     bdb.load_firefox_database(ff_db_path, None, add_pt)
@@ -1346,6 +1354,8 @@ def test_load_firefox_database(firefox_db, add_pt):
 def test_search_keywords_and_filter_by_tags(keyword_results, stag_results, exp_res):
     """test method."""
     # init
+    import buku
+
     bdb = buku.BukuDb()
     bdb.searchdb = mock.Mock(return_value=keyword_results)
     bdb.search_by_tag = mock.Mock(return_value=stag_results)
@@ -1368,6 +1378,8 @@ def test_search_keywords_and_filter_by_tags(keyword_results, stag_results, exp_r
 def test_exclude_results_from_search(search_results, exclude_results, exp_res):
     """test method."""
     # init
+    import buku
+
     bdb = buku.BukuDb()
     bdb.searchdb = mock.Mock(return_value=exclude_results)
     # test

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -879,10 +879,8 @@ def test_list_tags(capsys, setup):
     out, err = capsys.readouterr()
     prompt(bdb, None, True, listtags=True)
     out, err = capsys.readouterr()
-    assert (
-        out
-        == "     1. 1 (2)\n     2. 2 (1)\n     3. 3 (1)\n     4. ant (3)\n     5. bee (3)\n     6. cat (3)\n\n"
-    )
+    exp_out = "     1. 1 (2)\n     2. 2 (1)\n     3. 3 (1)\n     4. ant (3)\n     5. bee (3)\n     6. cat (3)\n\n"
+    assert out == exp_out
     assert err == ""
 
 

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1177,21 +1177,17 @@ def test_update_rec_invalid_tag(caplog, invalid_tag):
             raise e
 
 
-@pytest.mark.parametrize("read_in_retval", ["y", "n", ""])
-def test_update_rec_update_all_bookmark(caplog, read_in_retval):
+@pytest.mark.parametrize("read_in_retval, exp_res, record_tuples", [
+    ["y", False, [('root', 40, 'No matching index 0')]],
+    ["n", False, []],
+    ["", False, []],
+])
+def test_update_rec_update_all_bookmark(caplog, tmp_path, setup, read_in_retval, exp_res, record_tuples):
     """test method."""
-    caplog.set_level(logging.DEBUG)
     with mock.patch("buku.read_in", return_value=read_in_retval):
-        bdb = BukuDb()
+        bdb = BukuDb(tmp_path / 'tmp.db')
         res = bdb.update_rec(index=0, tags_in="tags1")
-        assert res if read_in_retval == "y" else not res
-        if read_in_retval == "y":
-            assert (
-                caplog.records[0].getMessage() == "update_rec query: "
-                "\"UPDATE bookmarks SET tags = ?\", args: [',tags1,']"
-            )
-        else:
-            assert not caplog.records
+        assert (res, caplog.record_tuples) == (exp_res, record_tuples)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1205,8 +1205,6 @@ def test_update_rec_update_all_bookmark(caplog, read_in_retval):
 def test_edit_update_rec_with_invalid_input(get_system_editor_retval, index, exp_res):
     """test method."""
     with mock.patch("buku.get_system_editor", return_value=get_system_editor_retval):
-        import buku
-
         bdb = buku.BukuDb()
         res = bdb.edit_update_rec(index=index)
         assert res == exp_res
@@ -1226,8 +1224,6 @@ def test_browse_by_index(low, high, index, is_range, empty_database):
     """test method."""
     n_low, n_high = (high, low) if low > high else (low, high)
     with mock.patch("buku.browse"):
-        import buku
-
         bdb = buku.BukuDb()
         bdb.delete_rec_all()
         db_len = 0
@@ -1278,8 +1274,6 @@ def test_load_chrome_database(chrome_db, add_pt):
             except RuntimeError:
                 res_yaml = yaml.load(f, Loader=PrettySafeLoader)
     # init
-    import buku
-
     bdb = buku.BukuDb()
     bdb.add_rec = mock.Mock()
     bdb.load_chrome_database(json_file, None, add_pt)
@@ -1325,8 +1319,6 @@ def test_load_firefox_database(firefox_db, add_pt):
             except RuntimeError:
                 res_yaml = yaml.load(f, Loader=PrettySafeLoader)
     # init
-    import buku
-
     bdb = buku.BukuDb()
     bdb.add_rec = mock.Mock()
     bdb.load_firefox_database(ff_db_path, None, add_pt)
@@ -1351,8 +1343,6 @@ def test_load_firefox_database(firefox_db, add_pt):
 def test_search_keywords_and_filter_by_tags(keyword_results, stag_results, exp_res):
     """test method."""
     # init
-    import buku
-
     bdb = buku.BukuDb()
     bdb.searchdb = mock.Mock(return_value=keyword_results)
     bdb.search_by_tag = mock.Mock(return_value=stag_results)
@@ -1375,8 +1365,6 @@ def test_search_keywords_and_filter_by_tags(keyword_results, stag_results, exp_r
 def test_exclude_results_from_search(search_results, exclude_results, exp_res):
     """test method."""
     # init
-    import buku
-
     bdb = buku.BukuDb()
     bdb.searchdb = mock.Mock(return_value=exclude_results)
     # test

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -12,9 +12,12 @@ import sys
 import unittest
 import urllib
 import zipfile
-from genericpath import exists
+
+# fmt: off
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
+from genericpath import exists
+# fmt: on
 
 import pytest
 import vcr

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1143,19 +1143,15 @@ def test_update_rec_index_0(caplog):
     assert caplog.records[0].levelname == "ERROR"
 
 
-def test_update_rec_only_index():
-    """test method."""
-    bdb = BukuDb()
-    res = bdb.update_rec(index=1)
-    assert res
-
-
-@pytest.mark.parametrize("url", [None, ""])
-def test_update_rec_invalid_url(url):
-    """test method."""
-    bdb = BukuDb()
-    res = bdb.update_rec(index=1, url=url)
-    assert res
+@pytest.mark.parametrize('kwargs, exp_res', [
+    [dict(index=1), False],
+    [dict(index=1, url='url'), False],
+    [dict(index=1, url=''), False],
+])
+def test_update_rec(tmp_path, kwargs, exp_res):
+    bdb = BukuDb(tmp_path / 'tmp.db')
+    res = bdb.update_rec(**kwargs)
+    assert res == exp_res
 
 
 @pytest.mark.parametrize("invalid_tag", ["+,", "-,"])

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1062,6 +1062,7 @@ def test_delete_rec_on_non_integer(
 ):
     """test delete rec on non integer arg."""
     import buku
+
     bdb = BukuDb(dbfile=tmp_path / "tmp.db")
 
     for bookmark in TEST_BOOKMARKS:
@@ -1143,13 +1144,16 @@ def test_update_rec_index_0(caplog):
     assert caplog.records[0].levelname == "ERROR"
 
 
-@pytest.mark.parametrize('kwargs, exp_res', [
-    [dict(index=1), False],
-    [dict(index=1, url='url'), False],
-    [dict(index=1, url=''), False],
-])
+@pytest.mark.parametrize(
+    "kwargs, exp_res",
+    [
+        [dict(index=1), False],
+        [dict(index=1, url="url"), False],
+        [dict(index=1, url=""), False],
+    ],
+)
 def test_update_rec(tmp_path, kwargs, exp_res):
-    bdb = BukuDb(tmp_path / 'tmp.db')
+    bdb = BukuDb(tmp_path / "tmp.db")
     res = bdb.update_rec(**kwargs)
     assert res == exp_res
 
@@ -1177,15 +1181,20 @@ def test_update_rec_invalid_tag(caplog, invalid_tag):
             raise e
 
 
-@pytest.mark.parametrize("read_in_retval, exp_res, record_tuples", [
-    ["y", False, [('root', 40, 'No matching index 0')]],
-    ["n", False, []],
-    ["", False, []],
-])
-def test_update_rec_update_all_bookmark(caplog, tmp_path, setup, read_in_retval, exp_res, record_tuples):
+@pytest.mark.parametrize(
+    "read_in_retval, exp_res, record_tuples",
+    [
+        ["y", False, [("root", 40, "No matching index 0")]],
+        ["n", False, []],
+        ["", False, []],
+    ],
+)
+def test_update_rec_update_all_bookmark(
+    caplog, tmp_path, setup, read_in_retval, exp_res, record_tuples
+):
     """test method."""
     with mock.patch("buku.read_in", return_value=read_in_retval):
-        bdb = BukuDb(tmp_path / 'tmp.db')
+        bdb = BukuDb(tmp_path / "tmp.db")
         res = bdb.update_rec(index=0, tags_in="tags1")
         assert (res, caplog.record_tuples) == (exp_res, record_tuples)
 


### PR DESCRIPTION
- delete_rec: index have default None value
- delete_rec: remove the table only when index is 0 instead of None based on index check
- delete_rec: index is now optional based on numpy definition
- delete_rec: no recommendation to use dummy index on is_range description. also no default value as it is stated on function definition
- delete_rec: example
- delete_rec: parameter check is changed see below for more 
- print_rec: description on database check
- print_rec: no recommendation to use dummy index
- print_rec: remove description of default value on is_range as it is stated on function definition
- print_rec: example
- print_rec: section on negative index only run when is_range is False
- setup: pytest vcr for vcr integration
- test_bukuDb: black formatted
- test_bukuDb: test_delete_rec_on_non_integer update, simplification and more control
- new: pre commit config https://pre-commit.com/index.html . some default is disabled to for minimal change for this pr
- other test: update_rec tests and test_update_rec_update_all_bookmark

before this i write on last pr

`delete_rec and print_rec state that some parameter is optional, but it may conflict with definition of mypy's optional`

i choose to keep it for consistency with other parameters

related pr:

https://github.com/jarun/buku/pull/495

---

parameter change on delete_rec function

before the change it is only stated that function will raise TypeError if any of index, low, or high variable is not integer.

but that error is from other function.

but simple check on all of the parameter is not enough because there is other clause on the description

on is_range description there is `An index is ignored if is_range is True`

so i put that as first priority before type check the parameter

so running `Buku().delete_rec(index='a', is_range=True)` will not raise the error because index is ignored before type check

