### PR TITLE
Don't accept command line arguments from standard input.

### DIFF
--- a/buku
+++ b/buku
@@ -4905,20 +4905,6 @@ def setup_logger(LOGGER):
     LOGGER.addHandler(sh)
 
 
-def piped_input(argv, pipeargs=None):
-    """Handle piped input.
-
-    Parameters
-    ----------
-    pipeargs : str
-    """
-    if not sys.stdin.isatty():
-        pipeargs += argv
-        print('waiting for input')
-        for s in sys.stdin:
-            pipeargs += s.split()
-
-
 def setcolors(args):
     """Get colors from user and separate into 'result' list for use in arg.colors.
 
@@ -5040,17 +5026,7 @@ def main():
     title_in = None
     tags_in = None
     desc_in = None
-    pipeargs = []
     colorstr_env = os.getenv('BUKU_COLORS')
-
-    try:
-        piped_input(sys.argv, pipeargs)
-    except KeyboardInterrupt:
-        pass
-
-    # If piped input, set argument vector
-    if pipeargs:
-        sys.argv = pipeargs
 
     # Setup custom argument parser
     argparser = ExtendedArgumentParser(


### PR DESCRIPTION
piped_input reads standard input and uses it as command line arguments.

piped_input blocks programs that launch buku but don't close standard
input. qutebrowser worked around piped_input by closing standard
input.

piped_input also prints `waiting for input\n` which breaks
non-interactive parsers that parse standard output of buku.

`waiting for input\n` broke my parser and someone else's parser.

A simple shell script can read standard input and pass it as command
line arguments to any program.

The behavior of piped_input isn't documented in `man buku` or `buku --help`.

Thus, piped_input isn't worth breaking common uses cases such as
non-interactive parsers and launching buku from another program.
By launching buku from another program, buku runs as a child process which may not have a tty as standard input.