### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bukuserver/static/bukuserver/js/Chart.js
+++ b/bukuserver/static/bukuserver/js/Chart.js
@@ -9429,7 +9429,7 @@ module.exports = Element.extend({
 		// Canvas doesn't allow us to stroke inside the width so we can
 		// adjust the sizes to fit if we're setting a stroke on the line
 		if (borderWidth) {
-			// borderWidth shold be less than bar width and bar height.
+			// borderWidth should be less than bar width and bar height.
 			var barSize = Math.min(Math.abs(left - right), Math.abs(top - bottom));
 			borderWidth = borderWidth > barSize ? barSize : borderWidth;
 			var halfStroke = borderWidth / 2;

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -268,7 +268,7 @@ class TestBukuDb(unittest.TestCase):
             for index, tagset in from_db:
                 # checking if new tags added to bookmark
                 self.assertTrue(split_and_test_membership(new_tags, tagset))
-                # checking if old tags still exist for boomark
+                # checking if old tags still exist for bookmark
                 self.assertTrue(split_and_test_membership(old_tagsets[index], tagset))
 
     def test_delete_tag_at_index(self):
@@ -277,7 +277,7 @@ class TestBukuDb(unittest.TestCase):
             self.bdb.add_rec(*bookmark)
 
         get_tags_at_idx = lambda i: self.bdb.get_rec_by_id(i)[3]
-        # list of two-tuples, each containg bookmark index and corresponding tags
+        # list of two-tuples, each containing bookmark index and corresponding tags
         tags_by_index = [
             (i, get_tags_at_idx(i)) for i in inclusive_range(1, len(self.bookmarks))
         ]


### PR DESCRIPTION
There are small typos in:
- bukuserver/static/bukuserver/js/Chart.js
- tests/test_bukuDb.py

Fixes:
- Should read `should` rather than `shold`.
- Should read `containing` rather than `containg`.
- Should read `bookmark` rather than `boomark`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md