### PR TITLE
[#539] Add nested folder structure tagging in import_html

### DIFF
--- a/buku
+++ b/buku
@@ -2555,13 +2555,23 @@ class BukuDb:
                 LOGERR(e)
                 return False
 
+            add_parent_folder_as_tag = False
+            use_nested_folder_structure = False
             if not tacit:
-                resp = input('Add parent folder names as tags? (y/n): ')
+                resp = input("""Add bookmark's parent folder as tag?
+y: add single, direct parent folder
+a: add all parent folders of the bookmark
+n: don't add parent folder as tag
+(y/a/[n]): """)
             else:
                 resp = 'y'
 
-            add_parent_folder_as_tag = (resp == 'y')
-            items = import_html(soup, add_parent_folder_as_tag, newtag)
+            if resp == 'y' or resp == 'a':
+                add_parent_folder_as_tag = True
+                if resp == 'a':
+                    use_nested_folder_structure = True
+
+            items = import_html(soup, add_parent_folder_as_tag, newtag, use_nested_folder_structure)
             infp.close()
 
         for item in items:
@@ -3315,7 +3325,7 @@ def import_firefox_json(json, add_bookmark_folder_as_tag=False, unique_tag=None)
     yield from iterate_children(None, main_entry_list)
 
 
-def import_html(html_soup, add_parent_folder_as_tag, newtag):
+def import_html(html_soup: BeautifulSoup, add_parent_folder_as_tag: bool, newtag: str, use_nested_folder_structure: bool = False):
     """Parse bookmark HTML.
 
     Parameters
@@ -3326,6 +3336,9 @@ def import_html(html_soup, add_parent_folder_as_tag, newtag):
         True if bookmark parent folders should be added as tags else False.
     newtag : str
         A new unique tag to add to imported bookmarks.
+    use_nested_folder_structure: bool
+        True if all bookmark parent folder should be added, not just direct parent else False
+        add_parent_folder_as_tag must be True for this flag to have an effect
 
     Returns
     -------
@@ -3350,19 +3363,36 @@ def import_html(html_soup, add_parent_folder_as_tag, newtag):
         if comment_tag:
             desc = comment_tag.find(text=True, recursive=False)
 
-        # add parent folder as tag
         if add_parent_folder_as_tag:
-            # could be its folder or not
-            possible_folder = tag.find_previous('h3')
-            # get list of tags within that folder
-            tag_list = tag.parent.parent.find_parent('dl')
+            # add parent folder as tag
+            if use_nested_folder_structure:
+                # New method that would generalize for else case too
+                # Stucture of folders
+                # dt
+                #   h3 (folder name)
+                #   dl
+                #       dt
+                #           a (could be h3, and continue recursively)
+                parents = tag.find_parents('dl')
+                for parent in parents:
+                    header = parent.find_previous_sibling('h3')
+                    if header:
+                        if tag.has_attr('tags'):
+                            tag['tags'] += (DELIM + header.text)
+                        else:
+                            tag['tags'] = header.text
+            else:
+                # could be its folder or not
+                possible_folder = tag.find_previous('h3')
+                # get list of tags within that folder
+                tag_list = tag.parent.parent.find_parent('dl')
 
-            if ((possible_folder) and possible_folder.parent in list(tag_list.parents)):
-                # then it's the folder of this bookmark
-                if tag.has_attr('tags'):
-                    tag['tags'] += (DELIM + possible_folder.text)
-                else:
-                    tag['tags'] = possible_folder.text
+                if ((possible_folder) and possible_folder.parent in list(tag_list.parents)):
+                    # then it's the folder of this bookmark
+                    if tag.has_attr('tags'):
+                        tag['tags'] += (DELIM + possible_folder.text)
+                    else:
+                        tag['tags'] = possible_folder.text
 
         # add unique tag if opted
         if newtag:

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -17,6 +17,15 @@ only_python_3_5 = pytest.mark.skipif(
     sys.version_info < (3, 5), reason="requires Python 3.5 or later")
 
 
+def check_import_html_results_contains(result, expected_result):
+    count = 0
+    for r in result:
+        for idx, exp_r in enumerate(expected_result):
+            if r == exp_r:
+                count += idx
+    n = len(expected_result) - 1
+    return count == n * (n+1)/2
+
 @pytest.mark.parametrize(
     'url, exp_res',
     [
@@ -686,6 +695,51 @@ def test_import_html_and_add_parent():
     html_soup = BeautifulSoup(html_text, 'html.parser')
     res = list(import_html(html_soup, True, None))
     assert res[0] == exp_res
+
+
+@pytest.mark.parametrize('add_all_parent, exp_res',[
+    (True,
+     [  ('http://example11.com', None, ',folder11,', None, 0, True, False),
+        ('http://example12.com', None, ',folder11,folder12,', None, 0, True, False),
+        ('http://example13.com', None, ',folder11,folder12,folder13,tag3,tag4,', None, 0, True, False),
+        ('http://example121.com', None, ',folder11,folder12,folder121,', None, 0, True, False)]
+    ),
+    (False,
+     [  ('http://example11.com', None, ',folder11,', None, 0, True, False),
+        ('http://example12.com', None, ',folder12,', None, 0, True, False),
+        ('http://example13.com', None, ',folder13,tag3,tag4,', None, 0, True, False)]
+    )
+])
+def test_import_html_and_add_all_parent(add_all_parent, exp_res):
+    from buku import import_html
+    from bs4 import BeautifulSoup
+    html_text = """
+<DL><p>
+<DT><H3>Folder01</H3><DL><p>
+    <DT><A HREF="http://example01.com"></A></DT>
+    <DT><H3>Folder02</H3><DL><p>
+        <DT><A HREF="http://example02.com"></A></DT>
+        <DT><H3>Folder03</H3><DL><p>
+            <DT><A HREF="http://example03.com" TAGS="tag1,tag2"></A></DT>
+        </DL><p></DT>
+    </DL><p></DT>
+</DL><p></DT>
+<DT><H3>Folder11</H3><DL><p>
+    <DT><A HREF="http://example11.com"></A></DT>
+    <DT><H3>Folder12</H3><DL><p>
+        <DT><H3>Folder121</H3><DL><p>
+            <DT><A HREF="http://example121.com"></A></DT>
+        </DL><p></DT>
+        <DT><A HREF="http://example12.com"></A></DT>
+        <DT><H3>Folder13</H3><DL><p>
+            <DT><A HREF="http://example13.com" TAGS="tag3,tag4"></A></DT>
+        </DL><p></DT>
+    </DL><p></DT>
+</DL><p></DT></DL>
+"""
+    html_soup = BeautifulSoup(html_text, 'html.parser')
+    res = list(import_html(html_soup, True, None, add_all_parent))
+    assert check_import_html_results_contains(res, exp_res)
 
 
 def test_import_html_and_new_tag():


### PR DESCRIPTION
## Description
See issue ticket for the feature being implemented.
Basically, so far only one parent folder was added as tag to a bookmark.
Now, every parent folder (in nested structure) will be added as tag/label to the bookmark. 
## Design note
Folder lookup changed to a relatively safe one that also able to do the work recursively.
## Test cases
Multiple branches to test if they influence each other (they shouldn't).
Some why when using find_parents('dt'), it found folders from other branch, when tested with my own data set.