### PR TITLE
readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.9'
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs


### PR DESCRIPTION
fix myst-parser module not found error

based on https://docs.readthedocs.io/en/stable/config-file/v2.html

https://stackoverflow.com/questions/69293277/how-to-import-markdown-with-sphinx-and-myst-parser-into-readthedocs

e: my readthedocs profile https://readthedocs.org/profiles/rachmadaniHaryono/