### PR TITLE
Remove `cgi` DeprecationWarning (Close #604)

### DIFF
--- a/buku
+++ b/buku
@@ -19,10 +19,10 @@
 
 import argparse
 import calendar
-import cgi
 import codecs
 import collections
 import contextlib
+import email
 import json
 import locale
 import logging
@@ -3809,14 +3809,14 @@ def get_data_from_page(resp):
         if soup.meta and soup.meta.get('charset') is not None:
             charset = soup.meta.get('charset')
         elif 'content-type' in resp.headers:
-            _, params = cgi.parse_header(resp.headers['content-type'])
+            _, params = email.message(resp.headers['content-type'])
             if params.get('charset') is not None:
                 charset = params.get('charset')
 
         if not charset and soup:
             meta_tag = soup.find('meta', attrs={'http-equiv': 'Content-Type'})
             if meta_tag:
-                _, params = cgi.parse_header(meta_tag.attrs['content'])
+                _, params = email.message(meta_tag.attrs['content'])
                 charset = params.get('charset', charset)
 
         if charset:

--- a/buku
+++ b/buku
@@ -22,7 +22,7 @@ import calendar
 import codecs
 import collections
 import contextlib
-import email
+import email.message
 import json
 import locale
 import logging
@@ -3809,15 +3809,17 @@ def get_data_from_page(resp):
         if soup.meta and soup.meta.get('charset') is not None:
             charset = soup.meta.get('charset')
         elif 'content-type' in resp.headers:
-            _, params = email.message(resp.headers['content-type'])
-            if params.get('charset') is not None:
-                charset = params.get('charset')
+            m = email.message.Message()
+            m['content-type'] = resp.headers['content-type']
+            if m.get_param('charset') is not None:
+                charset = m.get_param('charset')
 
         if not charset and soup:
             meta_tag = soup.find('meta', attrs={'http-equiv': 'Content-Type'})
             if meta_tag:
-                _, params = email.message(meta_tag.attrs['content'])
-                charset = params.get('charset', charset)
+                m = email.message.Message()
+                m['content'] = meta_tag.attrs['content']
+                charset = m.get_param('charset', charset)
 
         if charset:
             LOGDBG('charset: %s', charset)


### PR DESCRIPTION
I've checked the ToDo list and [PR guidelines](https://github.com/jarun/Buku/wiki/PR-guidelines).

## Description

Remove the DeprecationWarning `'cgi' is deprecated and slated for removal in Python 3.13`.

## Design notes

See possible methods in #604, I choose to replace `cgi` with `email`.

## Side effects

None since `cgi` and `email` are all standard libraries (https://docs.python.org/3.11/library/email.html).

## Test cases

I cloned the repo, made a fix and installed the updated buku using `python setup.py install` inside an isolated virtualenv and it does not show the deprecation warning anymore. The linting test running locally with `python3 -m pylint buku` passed as well.

## Documentation

Didn't touch as I think it's not related.