### PR TITLE
[bukuserver] Bookmark details overflow fix

### DIFF
--- a/bukuserver/static/bukuserver/css/bookmark.css
+++ b/bukuserver/static/bukuserver/css/bookmark.css
@@ -1,0 +1,11 @@
+/* preventing layout overflow in tables */
+table tr td:not(:first-child) {
+    overflow-wrap: anywhere;
+}
+
+/* wider modals for wide data */
+@media (min-width: 768px) {
+    .modal-dialog {
+        width: min(1000px, 80%);
+    }
+}

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -144,6 +144,7 @@ class BookmarkModelView(BaseModelView):
     edit_modal_template = "bukuserver/bookmark_edit_modal.html"
     edit_template = "bukuserver/bookmark_edit.html"
     named_filter_urls = True
+    extra_css = ['/static/bukuserver/css/bookmark.css']
 
     def __init__(self, *args, **kwargs):
         self.bukudb: buku.BukuDb = args[0]
@@ -271,7 +272,7 @@ class BookmarkModelView(BaseModelView):
                     value = value[1:]
                 if value.endswith(","):
                     value = value[:-1]
-                setattr(bm_sns, field.name.lower(), value)
+                setattr(bm_sns, field.name.lower(), value.replace(',', ', '))
             else:
                 setattr(bm_sns, field.name.lower(), bookmark[field.value])
         return bm_sns


### PR DESCRIPTION
fixes #607
* adding spaces between tags in a single bookmark view (only the details modal/page appears to be affected)
* preventing layout overflow in tables (by ensuring that long lines wrap)
* increasing bookmark modals width (getting it closer to list width, thus improving viewing experience for long lines)