### PR TITLE
[bukuserver] Tags-refresh action

### DIFF
--- a/bukuserver/templates/bukuserver/tags_list.html
+++ b/bukuserver/templates/bukuserver/tags_list.html
@@ -1,0 +1,7 @@
+{% extends 'admin/model/list.html' %}
+
+{% block model_menu_bar_before_filters %}
+  {{ super() }}
+  <form id="refresh" style="display:none" method="POST" action="refresh"></form>
+  <li><a href="#" onclick="refresh.submit()">{{ _gettext('Refresh') }}</a></li>
+{% endblock %}

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -445,6 +445,7 @@ class TagModelView(BaseModelView):
     column_formatters = {
         "name": _name_formatter,
     }
+    list_template = 'bukuserver/tags_list.html'
 
     def __init__(self, *args, **kwargs):
         self.bukudb = args[0]
@@ -455,6 +456,11 @@ class TagModelView(BaseModelView):
         ] + list(args[1:])
         self.page_size = kwargs.pop("page_size", DEFAULT_PER_PAGE)
         super().__init__(*args, **kwargs)
+
+    @expose('/refresh', methods=['POST'])
+    def refresh(self):
+        self.all_tags = self.bukudb.get_tag_all()
+        return redirect(request.referrer or url_for('tags.index_page'))
 
     def scaffold_list_columns(self):
         return ["name", "usage_count"]


### PR DESCRIPTION
fixes #608:
* adding a "Refresh" button to the tags actions panel
* implementing a POST endpoint to reload tags list

P.S. Is `tags.html` actually used anywhere? I get the feeling that about half of existing templates have been substituted completely by default flask-admin ones. (They seem to be [mentioned in the code](https://github.com/jarun/buku/blob/ba9d62b11871171bf37a8a2c8ad90380659bfffc/bukuserver/server.py#L54-L64) but these functions don't appear to be actually used anywhere…)