### PR TITLE
[bukuserver] Last page endpoint

### DIFF
--- a/bukuserver/static/bukuserver/js/last_page.js
+++ b/bukuserver/static/bukuserver/js/last_page.js
@@ -1,0 +1,4 @@
+$(document).ready(function() {
+  $(`.pagination :contains("»") a`).not(`[href^="javascript:"]`).attr('href', (idx, href) =>
+    href.replace(/\/?(\?|$)/, '/last-page$1').replace(/([?&]page=)[0-9]+(&|$)/, '$1-1$2'));
+});

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -50,7 +50,8 @@ class CustomAdminIndexView(AdminIndexView):
 
 
 def last_page(self):
-    """Generic '/last_page' endpoint handler"""
+    """Generic '/last_page' endpoint handler; based on
+    https://github.com/flask-admin/flask-admin/blob/v1.6.0/flask_admin/model/base.py#L1956-L1969 """
     # Grab parameters from URL
     view_args = self._get_list_extra_args()
 


### PR DESCRIPTION
fixes #606:
* implementing a generic `/last-page` endpoint handler (for any `BaseModelView` subclass)
* overriding the last-page pagination link at runtime
* applying both to bookmark & tag lists
* also chainging the redirect in `/tags/refresh` handler to retain consistency.