### PR TITLE
[bukuserver] Readonly mode

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -119,7 +119,8 @@ Following are available os env config available for bukuserver.
 | SECRET_KEY | server secret key | string [default: os.urandom(24)] |
 | URL_RENDER_MODE | url render mode | `full` or `netloc` [default: `full`] |
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
-| DISABLE_FAVICON | disable favicon | boolean [default: `true`] |
+| READONLY | read-only mode | boolean [default: `false`] |
+| DISABLE_FAVICON | disable bookmark favicons | boolean [default: `true`] |
 | OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
 | REVERSE_PROXY_PATH | reverse proxy path | string |
 

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -202,6 +202,8 @@ def create_app(db_file=None):
         url_render_mode = views.DEFAULT_URL_RENDER_MODE
     app.config['BUKUSERVER_URL_RENDER_MODE'] = url_render_mode
     app.config['SECRET_KEY'] = os.getenv('BUKUSERVER_SECRET_KEY') or os.urandom(24)
+    app.config['BUKUSERVER_READONLY'] = \
+        get_bool_from_env_var('BUKUSERVER_READONLY', False)
     app.config['BUKUSERVER_DISABLE_FAVICON'] = \
         get_bool_from_env_var('BUKUSERVER_DISABLE_FAVICON', True)
     app.config['BUKUSERVER_OPEN_IN_NEW_TAB'] = \

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -72,6 +72,13 @@ def last_page(self):
     return redirect(url_for('.index_view', **args))
 
 
+def readonly_check(self):
+    if current_app.config.get("BUKUSERVER_READONLY", False):
+        self.can_create = False
+        self.can_edit = False
+        self.can_delete = False
+
+
 class BookmarkModelView(BaseModelView):
     @staticmethod
     def _filter_arg(flt):
@@ -109,7 +116,7 @@ class BookmarkModelView(BaseModelView):
         res = []
         if not current_app.config.get("BUKUSERVER_DISABLE_FAVICON", False) and netloc:
             res.append(
-                f'<img src="http://www.google.com/s2/favicons?domain={netloc}"/>'
+                f'<img src="http://www.google.com/s2/favicons?domain={netloc}"/> '
             )
         title = model.title if model.title else "&lt;EMPTY TITLE&gt;"
         open_in_new_tab = current_app.config.get("BUKUSERVER_OPEN_IN_NEW_TAB", False)
@@ -159,6 +166,7 @@ class BookmarkModelView(BaseModelView):
     last_page = expose('/last-page')(last_page)
 
     def __init__(self, *args, **kwargs):
+        readonly_check(self)
         self.bukudb: buku.BukuDb = args[0]
         custom_model = types.SimpleNamespace(bukudb=self.bukudb, __name__="bookmark")
         args = [
@@ -453,6 +461,7 @@ class TagModelView(BaseModelView):
     last_page = expose('/last-page')(last_page)
 
     def __init__(self, *args, **kwargs):
+        readonly_check(self)
         self.bukudb = args[0]
         self.all_tags = self.bukudb.get_tag_all()
         custom_model = types.SimpleNamespace(bukudb=self.bukudb, __name__="tag")


### PR DESCRIPTION
fixes #549:
* adding a `BUKUSERVER_READONLY` boolean environment variable
* implementing a generic editing disabler for a model based on the value of said variable
* applying said disabler to bookmark & tag models

also:
* improving description of `DISABLE_FAVICON` (for clarity)
* adding a space after the bookmark favicon for visual improvement