### PR TITLE
[bukuserver] Hyperlinks in create/edit success messages

### DIFF
--- a/bukuserver/static/bukuserver/js/flash.js
+++ b/bukuserver/static/bukuserver/js/flash.js
@@ -1,0 +1,4 @@
+$(document).ready(function () {
+  SAVED && $(`.alert-success`).first().html((_, s) =>
+    s.replace(/(<\/button>)([^]*)$/, `$1<a href="details?id=${SAVED}">$2</a>`));
+});

--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -1,5 +1,10 @@
 {% extends 'admin/model/create.html' %}
 
+{% block head %}
+  {{ super() }}
+  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
+{% endblock %}
+
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -1,0 +1,6 @@
+{% extends 'admin/model/details.html' %}
+
+{% block head %}
+  {{ super() }}
+  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
+{% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_edit.html
+++ b/bukuserver/templates/bukuserver/bookmark_edit.html
@@ -1,5 +1,10 @@
 {% extends 'admin/model/edit.html' %}
 
+{% block head %}
+  {{ super() }}
+  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
+{% endblock %}
+
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>

--- a/bukuserver/templates/bukuserver/bookmarks_list.html
+++ b/bukuserver/templates/bukuserver/bookmarks_list.html
@@ -1,0 +1,6 @@
+{% extends 'admin/model/list.html' %}
+
+{% block head %}
+  {{ super() }}
+  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
+{% endblock %}

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 import arrow
 import wtforms
-from flask import current_app, flash, redirect, request, url_for
+from flask import current_app, flash, redirect, request, session, url_for
 from flask_admin.babel import gettext
 from flask_admin.base import AdminIndexView, BaseView, expose
 from flask_admin.model import BaseModelView
@@ -153,6 +153,8 @@ class BookmarkModelView(BaseModelView):
         "Entry": _list_entry,
     }
     column_list = ["Entry"]
+    list_template = 'bukuserver/bookmarks_list.html'
+    details_template = 'bukuserver/bookmark_details.html'
     create_modal = True
     create_modal_template = "bukuserver/bookmark_create_modal.html"
     create_template = "bukuserver/bookmark_create.html"
@@ -162,7 +164,7 @@ class BookmarkModelView(BaseModelView):
     edit_template = "bukuserver/bookmark_edit.html"
     named_filter_urls = True
     extra_css = ['/static/bukuserver/css/bookmark.css']
-    extra_js = ['/static/bukuserver/js/' + it for it in ('page_size.js', 'last_page.js')]
+    extra_js = ['/static/bukuserver/js/' + it for it in ('page_size.js', 'last_page.js', 'flash.js')]
     last_page = expose('/last-page')(last_page)
 
     def __init__(self, *args, **kwargs):
@@ -202,7 +204,7 @@ class BookmarkModelView(BaseModelView):
             for key, item in (("title_in", model.title), ("desc", model.description)):
                 if item.strip():
                     kwargs[key] = item
-            vars(model)['id'] = self.model.bukudb.add_rec(**kwargs)
+            session['saved'] = vars(model)['id'] = self.model.bukudb.add_rec(**kwargs)
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 msg = "Failed to create record."
@@ -409,6 +411,7 @@ class BookmarkModelView(BaseModelView):
                 tags_in=buku.parse_tags([model.tags]),
                 desc=model.description,
             )
+            session['saved'] = model.id
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 msg = "Failed to update record."


### PR DESCRIPTION
fixes #564:
* saving the ID of created/updated bookmark record to session context
* rendering subsequent bookmarks page with said ID injected as a JS value
* detecting first success alert (flash) and wrapping text in it into a hyperlink to the page of a respective bookmark  
  _note: alerts are plain text and have [dozens of variations](https://github.com/flask-admin/flask-admin/tree/v1.6.0/flask_admin/translations), so not much can be done about improving detection accuracy_