### PR TITLE
[bukuserver] Non-conflicting URL parameters in GUI

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -116,7 +116,7 @@ Following are available os env config available for bukuserver.
 | Name (without prefix) | Description | Value |
 | --- | --- | --- |
 | PER_PAGE | bookmarks per page | positive integer [default: 10] |
-| SECRET_KEY | server secret key | string [default: os.urandom(24)] |
+| SECRET_KEY | [flask secret key](https://flask.palletsprojects.com/config/#SECRET_KEY) | string [default: os.urandom(24)] |
 | URL_RENDER_MODE | url render mode | `full` or `netloc` [default: `full`] |
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
 | READONLY | read-only mode | boolean [default: `false`] |

--- a/bukuserver/forms.py
+++ b/bukuserver/forms.py
@@ -16,7 +16,10 @@ class HomeForm(SearchBookmarksForm):
 
 
 class BookmarkForm(FlaskForm):
-    url = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    url = wtforms.StringField('Url', name='link', validators=[wtforms.validators.DataRequired()])
     title = wtforms.StringField()
     tags = wtforms.StringField()
     description = wtforms.TextAreaField()
+
+class ApiBookmarkForm(BookmarkForm):
+    url = wtforms.StringField(validators=[wtforms.validators.DataRequired()])

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -266,7 +266,7 @@ class ApiBookmarkView(MethodView):
                 result_bookmark = {
                     'url': bookmark[1],
                     'title': bookmark[2],
-                    'tags': list(filter(lambda x: x, bookmark[3].split(','))),
+                    'tags': [x for x in bookmark[3].split(',') if x],
                     'description': bookmark[4]
                 }
                 if not request.path.startswith('/api/'):
@@ -280,7 +280,7 @@ class ApiBookmarkView(MethodView):
                 result = {
                     'url': bookmark[1],
                     'title': bookmark[2],
-                    'tags': list(filter(lambda x: x, bookmark[3].split(','))),
+                    'tags': [x for x in bookmark[3].split(',') if x],
                     'description': bookmark[4]
                 }
                 res = jsonify(result)
@@ -291,7 +291,7 @@ class ApiBookmarkView(MethodView):
 
     def post(self, rec_id: None = None):
         bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        create_bookmarks_form = forms.BookmarkForm()
+        create_bookmarks_form = forms.ApiBookmarkForm()
         url_data = create_bookmarks_form.url.data
         result_flag = bukudb.add_rec(
             url_data,
@@ -362,7 +362,7 @@ class ApiBookmarkRangeView(MethodView):
             result['bookmarks'][i] = {
                 'url': bookmark[1],
                 'title': bookmark[2],
-                'tags': list(filter(lambda x: x, bookmark[3].split(','))),
+                'tags': [x for x in bookmark[3].split(',') if x],
                 'description': bookmark[4]
             }
         res = jsonify(result)
@@ -485,7 +485,7 @@ class BookmarkletView(MethodView):  # pylint: disable=too-few-public-methods
         rec_id = bukudb.get_rec_id(url)
         if rec_id >= 0:
             return redirect(url_for('bookmark.edit_view', id=rec_id))
-        return redirect(url_for('bookmark.create_view', url=url, title=title, description=description))
+        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description))
 
 
 class CustomFlaskGroup(FlaskGroup):  # pylint: disable=too-few-public-methods

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -4,3 +4,12 @@
   {{ super() }}
   <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
 {% endblock %}
+
+{% block tail %}
+  {{ super() }}
+  <script>{
+    let target = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
+    $(`td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'))
+    $(`td:contains("Url") + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${target}>${s}</a>`);
+  }</script>
+{% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_details_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_details_modal.html
@@ -1,0 +1,10 @@
+{% extends 'admin/model/modals/details.html' %}
+
+{% block tail %}
+  {{ super() }}
+  <script>{
+    let target = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
+    $(`.modal td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'))
+    $(`.modal td:contains("Url") + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${target}>${s}</a>`);
+  }</script>
+{% endblock %}

--- a/bukuserver/templates/bukuserver/statistic.html
+++ b/bukuserver/templates/bukuserver/statistic.html
@@ -29,7 +29,7 @@
       {% for item, number, _ in most_common_netlocs %}
       <tr>
         <td>{{loop.index}}</td>
-        <td> <a href="{{url_for('bookmark.index_view', flt1_url_netloc_match=item)}}">{{item}}</a> </td>
+        <td> <a href="{{url_for('bookmark.index_view', flt0_url_netloc_match=item)}}">{{item}}</a> </td>
         <td class="text-right">{{number}}</td>
       </tr>
       {% endfor %}
@@ -60,7 +60,7 @@
                 <td>{{loop.index}}</td>
                 <td>
                   {% if item %}
-                  <a href="{{url_for('bookmark.index_view', flt1_url_netloc_match=item)}}">{{item}}</a>
+                  <a href="{{url_for('bookmark.index_view', flt0_url_netloc_match=item)}}">{{item}}</a>
                   {% else %}
                   <span class="btn btn-default" disabled="disabled">(No Netloc)</span>
                   {% endif %}
@@ -99,7 +99,7 @@
       <tr>
         <td>{{loop.index}}</td>
         <td>
-          <a href="{{url_for('bookmark.index_view', flt3_tags_contain=item)}}">{{item}}</a>
+          <a href="{{url_for('bookmark.index_view', flt0_tags_contain=item)}}">{{item}}</a>
         </td>
         <td class="text-right">{{number}}</td>
       </tr>
@@ -128,7 +128,7 @@
             {% for item, number in tag_counter.most_common() %}
               <tr>
                 <td>{{loop.index}}</td>
-                <td> <a href="{{url_for('bookmark.index_view', flt3_tags_contain=item)}}">{{item}}</a> </td>
+                <td> <a href="{{url_for('bookmark.index_view', flt0_tags_contain=item)}}">{{item}}</a> </td>
                 <td class="text-right">{{number}}</td>
               </tr>
             {% endfor %}
@@ -219,8 +219,8 @@
   {{ super() }}
   <script src="{{url_for('static', filename='bukuserver/js/Chart.js')}}"></script>
   <script>
-  var ctx = document.getElementById("mostCommonChart").getContext('2d');
-  var netlocChart = new Chart(ctx, {
+  var netlocCtx = document.getElementById("mostCommonChart").getContext('2d');
+  var netlocChart = new Chart(netlocCtx, {
     type: 'pie',
     data: {
       datasets: [{
@@ -228,12 +228,12 @@
           {% for val in most_common_netlocs %} {{val.1}}, {% endfor %}
         ],
         backgroundColor: [
-          {% for val in most_common_netlocs %} "{{val.2}}", {% endfor %}
+          {% for val in most_common_netlocs %} {{val.2|tojson}}, {% endfor %}
         ],
       }],
       // These labels appear in the legend and in the tooltips when hovering different arcs
       labels: [
-        {% for val in most_common_netlocs %} "{{val.0}}", {% endfor %}
+        {% for val in most_common_netlocs %} {{val.0|tojson}}, {% endfor %}
       ]
     },
     options: {
@@ -247,7 +247,7 @@
         var field = $('<input></input>');
 
         field.attr("type", "hidden");
-        field.attr("name", "flt1_url_netloc_match");
+        field.attr("name", "flt0_url_netloc_match");
         field.attr("value", value);
         form.append(field);
 
@@ -268,25 +268,25 @@
           {% for val in most_common_tags %} {{val.1}}, {% endfor %}
         ],
         backgroundColor: [
-          {% for val in most_common_tags %} "{{val.2}}", {% endfor %}
+          {% for val in most_common_tags %} {{val.2|tojson}}, {% endfor %}
         ],
       }],
       // These labels appear in the legend and in the tooltips when hovering different arcs
       labels: [
-        {% for val in most_common_tags %} "{{val.0}}", {% endfor %}
+        {% for val in most_common_tags %} {{val.0|tojson}}, {% endfor %}
       ]
     },
     options: {
       'onClick' : function (evt, item) {
         var tagStr = this.data.labels[item[0]._index];
-        var url = "{{url_for('bookmark.index_view')}}?flt3_tags_contain=" + tagStr;
+        var url = "{{url_for('bookmark.index_view')}}?flt0_tags_contain=" + encodeURIComponent(tagStr);
         window.location.href = url;
       }
     }
   });
 
-  var ctx = document.getElementById("mostCommonTitleChart").getContext('2d');
-  var netlocChart = new Chart(ctx, {
+  var titleCtx = document.getElementById("mostCommonTitleChart").getContext('2d');
+  var titleChart = new Chart(titleCtx, {
     type: 'pie',
     data: {
       datasets: [{
@@ -294,12 +294,12 @@
           {% for val in most_common_titles %} {{val.1}}, {% endfor %}
         ],
         backgroundColor: [
-          {% for val in most_common_titles %} "{{val.2}}", {% endfor %}
+          {% for val in most_common_titles %} {{val.2|tojson}}, {% endfor %}
         ],
       }],
       // These labels appear in the legend and in the tooltips when hovering different arcs
       labels: [
-        {% for val in most_common_titles %} "{{val.0|trim}}", {% endfor %}
+        {% for val in most_common_titles %} {{val.0|trim|tojson}}, {% endfor %}
       ]
     },
     options: {
@@ -325,7 +325,7 @@
     }
   });
 
-  netlocChart.canvas.parentNode.style.height = '128px';
+  titleChart.canvas.parentNode.style.height = '128px';
   </script>
 
 </div>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -85,12 +85,12 @@ def bmv_instance(tmp_path):
     return inst
 
 
-@pytest.mark.parametrize('url, exp_url', [
-    ['http://example.com', 'http://example.com'],
-    ['/bookmark/', None],
+@pytest.mark.parametrize('url, backlink', [
+    ['http://example.com', None],
+    ['http://example.com', '/bookmark/'],
 ])
-def test_bmv_create_form(bmv_instance, url, exp_url, app):
+def test_bmv_create_form(bmv_instance, url, backlink, app):
     with app.test_request_context():
-        request.args = {"url": url}
+        request.args = {'link': url, 'url': backlink} if backlink else {'link': url}
         form = bmv_instance.create_form()
-        assert form.url.data == exp_url
+        assert form.url.data == url


### PR DESCRIPTION
fixes #635:
* renaming the `url` param to `link` in HTML forms & queries (excluding the API)

also:
* clarifying the purpose of `BUKUSERVER_SECRET_KEY` (in readme)
* normalizing filter parameter indices in `statistic.html` (see #624)
* fixing `BUKUSERVER_OPEN_IN_NEW_TAB` (broken in current master)
* fixing [Little Bobby Tables](https://xkcd.com/327) (as well as incorrectly encoded values)
* adding custom formatting to details page/modal (linebreaks, hyperlink in **Url** field)