### PR TITLE
[bukuserver] Bookmarklet, optional fetch, refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ buku.py
 /tests/test_bukuDb/places.sqlite*
 /tests/vcr_cassettes/test_search_and_open_all_in_browser.yaml
 /tests/vcr_cassettes/tests.test_bukuDb/
+/bookmarks.db

--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -111,9 +111,9 @@ See more option on `bukuserver run --help` and `bukuserver --help`
 
 ### Configuration
 
-Following are available os env config available for bukuserver.
+The following are os env config variables available for bukuserver.
 
-| Name (without prefix) | Description | Value |
+| Name (_without prefix_) | Description | Value |
 | --- | --- | --- |
 | PER_PAGE | bookmarks per page | positive integer [default: 10] |
 | SECRET_KEY | [flask secret key](https://flask.palletsprojects.com/config/#SECRET_KEY) | string [default: os.urandom(24)] |
@@ -124,7 +124,9 @@ Following are available os env config available for bukuserver.
 | OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
 | REVERSE_PROXY_PATH | reverse proxy path | string |
 
-Note: `BUKUSERVER_` is the common prefix.
+Note: `BUKUSERVER_` is the common prefix (_every variable starts with it_).
+
+Note: Valid boolean values are `true`, `false`, `1`, `0` (case-insensitive).
 
 Note: if input is invalid, the default value will be used if defined
 

--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -123,6 +123,7 @@ The following are os env config variables available for bukuserver.
 | DISABLE_FAVICON | disable bookmark [favicons](https://wikipedia.org/wiki/Favicon) | boolean [default: `true`] |
 | OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
 | REVERSE_PROXY_PATH | reverse proxy path | string |
+| LOCALE | GUI language (partial support) | string [default: `en`] |
 
 Note: `BUKUSERVER_` is the common prefix (_every variable starts with it_).
 

--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+# pylint: disable=wrong-import-order, ungrouped-imports
+"""Server module."""
+import collections
+import typing as T
+from typing import Any, Dict, Union  # NOQA; type: ignore
+from unittest import mock
+
+from flask.views import MethodView
+from flask_api import exceptions, status
+
+import buku
+from buku import BukuDb
+
+import flask
+from flask import current_app, jsonify, redirect, request, url_for
+
+try:
+    from . import forms, response
+except ImportError:
+    from bukuserver import forms, response
+
+
+STATISTIC_DATA = None
+
+response_ok = lambda: (jsonify(response.response_template['success']),
+                       status.HTTP_200_OK,
+                       {'ContentType': 'application/json'})
+response_bad = lambda: (jsonify(response.response_template['failure']),
+                        status.HTTP_400_BAD_REQUEST,
+                        {'ContentType': 'application/json'})
+to_response = lambda ok: response_ok() if ok else response_bad()
+
+
+def get_bukudb():
+    """get bukudb instance"""
+    db_file = current_app.config.get('BUKUSERVER_DB_FILE', None)
+    return BukuDb(dbfile=db_file)
+
+
+def search_tag(
+    db: BukuDb, stag: T.Optional[str] = None, limit: T.Optional[int] = None
+) -> T.Tuple[T.List[str], T.Dict[str, int]]:
+    """search tag.
+
+    db:
+        buku db instance
+    stag:
+        search tag
+    limit:
+        positive integer limit
+
+    Returns
+    -------
+    tuple
+        list of unique tags sorted alphabetically and dictionary of tag and its usage count
+
+    Raises
+    ------
+    ValueError
+        if limit is not positive
+    """
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be positive")
+    tags: T.Set[str] = set()
+    counter = collections.Counter()
+    query_list = ["SELECT DISTINCT tags , COUNT(tags) FROM bookmarks"]
+    if stag:
+        query_list.append("where tags LIKE :search_tag")
+    query_list.append("GROUP BY tags")
+    row: T.Tuple[str, int]
+    for row in db.cur.execute(" ".join(query_list), {"search_tag": f"%{stag}%"}):
+        for tag in row[0].strip(buku.DELIM).split(buku.DELIM):
+            if not tag:
+                continue
+            tags.add(tag)
+            counter[tag] += row[1]
+    return list(sorted(tags)), dict(counter.most_common(limit))
+
+
+class ApiTagView(MethodView):
+
+    def get(self, tag: T.Optional[str]):
+        bukudb = get_bukudb()
+        if tag is None:
+            return {"tags": search_tag(db=bukudb, limit=5)[0]}
+        tags = search_tag(db=bukudb, stag=tag)
+        if tag not in tags[1]:
+            raise exceptions.NotFound()
+        return dict(name=tag, usage_count=tags[1][tag])
+
+    def put(self, tag: str):
+        bukudb = get_bukudb()
+        try:
+            new_tags = request.data.get('tags')  # type: ignore
+            if new_tags:
+                new_tags = new_tags.split(',')
+            else:
+                return response_bad()
+        except AttributeError as e:
+            raise exceptions.ParseError(detail=str(e))
+        return to_response(bukudb.replace_tag(tag, new_tags))
+
+
+class ApiBookmarkView(MethodView):
+
+    def get(self, rec_id: Union[int, None]):
+        if rec_id is None:
+            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+            all_bookmarks = bukudb.get_rec_all()
+            result = {'bookmarks': []}  # type: Dict[str, Any]
+            for bookmark in all_bookmarks:
+                result_bookmark = {
+                    'url': bookmark[1],
+                    'title': bookmark[2],
+                    'tags': [x for x in bookmark[3].split(',') if x],
+                    'description': bookmark[4]
+                }
+                if not request.path.startswith('/api/'):
+                    result_bookmark['id'] = bookmark[0]
+                result['bookmarks'].append(result_bookmark)
+            res = jsonify(result)
+        else:
+            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+            bookmark = bukudb.get_rec_by_id(rec_id)
+            if bookmark is None:
+                res = response_bad()
+            else:
+                res = jsonify({
+                    'url': bookmark[1],
+                    'title': bookmark[2],
+                    'tags': [x for x in bookmark[3].split(',') if x],
+                    'description': bookmark[4]
+                })
+        return res
+
+    def post(self, rec_id: None = None):
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        create_bookmarks_form = forms.ApiBookmarkForm()
+        url_data = create_bookmarks_form.url.data
+        result_flag = bukudb.add_rec(
+            url_data,
+            create_bookmarks_form.title.data,
+            create_bookmarks_form.tags.data,
+            create_bookmarks_form.description.data
+        )
+        return to_response(result_flag != -1)
+
+    def put(self, rec_id: int):
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        result_flag = bukudb.update_rec(
+            rec_id,
+            request.form.get('url'),
+            request.form.get('title'),
+            request.form.get('tags'),
+            request.form.get('description'))
+        return to_response(result_flag)
+
+    def delete(self, rec_id: Union[int, None]):
+        if rec_id is None:
+            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+            with mock.patch('buku.read_in', return_value='y'):
+                result_flag = bukudb.cleardb()
+        else:
+            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+            result_flag = bukudb.delete_rec(rec_id)
+        return to_response(result_flag)
+
+
+class ApiBookmarkRangeView(MethodView):
+
+    def get(self, starting_id: int, ending_id: int):
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        max_id = bukudb.get_max_id()
+        if starting_id > max_id or ending_id > max_id:
+            return response_bad()
+        result = {'bookmarks': {}}  # type: ignore
+        for i in range(starting_id, ending_id + 1, 1):
+            bookmark = bukudb.get_rec_by_id(i)
+            result['bookmarks'][i] = {
+                'url': bookmark[1],
+                'title': bookmark[2],
+                'tags': [x for x in bookmark[3].split(',') if x],
+                'description': bookmark[4]
+            }
+        return jsonify(result)
+
+    def put(self, starting_id: int, ending_id: int):
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        max_id = bukudb.get_max_id()
+        if starting_id > max_id or ending_id > max_id:
+            return response_bad()
+        for i in range(starting_id, ending_id + 1, 1):
+            updated_bookmark = request.data.get(str(i))  # type: ignore
+            result_flag = bukudb.update_rec(
+                i,
+                updated_bookmark.get('url'),
+                updated_bookmark.get('title'),
+                updated_bookmark.get('tags'),
+                updated_bookmark.get('description'))
+            if result_flag is False:
+                return response_bad()
+        return response_ok()
+
+    def delete(self, starting_id: int, ending_id: int):
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        max_id = bukudb.get_max_id()
+        if starting_id > max_id or ending_id > max_id:
+            return response_bad()
+        idx = min([starting_id, ending_id])
+        result_flag = bukudb.delete_rec(idx, starting_id, ending_id, is_range=True)
+        return to_response(result_flag)
+
+
+class ApiBookmarkSearchView(MethodView):
+
+    def get(self):
+        arg_obj = request.args
+        keywords = arg_obj.getlist('keywords')
+        all_keywords = arg_obj.get('all_keywords')
+        deep = arg_obj.get('deep')
+        regex = arg_obj.get('regex')
+        # api request is more strict
+        all_keywords = False if all_keywords is None else all_keywords
+        deep = False if deep is None else deep
+        regex = False if regex is None else regex
+        all_keywords = (
+            all_keywords if isinstance(all_keywords, bool) else
+            all_keywords.lower() == 'true'
+        )
+        deep = deep if isinstance(deep, bool) else deep.lower() == 'true'
+        regex = regex if isinstance(regex, bool) else regex.lower() == 'true'
+
+        result = {'bookmarks': []}
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        found_bookmarks = bukudb.searchdb(keywords, all_keywords, deep, regex)
+        found_bookmarks = [] if found_bookmarks is None else found_bookmarks
+        res = None
+        if found_bookmarks is not None:
+            for bookmark in found_bookmarks:
+                result_bookmark = {
+                    'id': bookmark[0],
+                    'url': bookmark[1],
+                    'title': bookmark[2],
+                    'tags': list(filter(lambda x: x, bookmark[3].split(','))),
+                    'description': bookmark[4]
+                }
+                result['bookmarks'].append(result_bookmark)
+        current_app.logger.debug('total bookmarks:{}'.format(len(result['bookmarks'])))
+        res = jsonify(result)
+        return res
+
+    def delete(self):
+        arg_obj = request.form
+        keywords = arg_obj.getlist('keywords')
+        all_keywords = arg_obj.get('all_keywords')
+        deep = arg_obj.get('deep')
+        regex = arg_obj.get('regex')
+        # api request is more strict
+        all_keywords = False if all_keywords is None else all_keywords
+        deep = False if deep is None else deep
+        regex = False if regex is None else regex
+        all_keywords = (
+            all_keywords if isinstance(all_keywords, bool) else
+            all_keywords.lower() == 'true'
+        )
+        deep = deep if isinstance(deep, bool) else deep.lower() == 'true'
+        regex = regex if isinstance(regex, bool) else regex.lower() == 'true'
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        found_bookmarks = bukudb.searchdb(keywords, all_keywords, deep, regex)
+        found_bookmarks = [] if found_bookmarks is None else found_bookmarks
+        res = None
+        if found_bookmarks is not None:
+            for bookmark in found_bookmarks:
+                if not bukudb.delete_rec(bookmark[0]):
+                    res = response_bad()
+        return res or response_ok()
+
+
+class BookmarkletView(MethodView):  # pylint: disable=too-few-public-methods
+    def get(self):
+        url = request.args.get('url')
+        title = request.args.get('title')
+        description = request.args.get('description')
+
+        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
+        rec_id = bukudb.get_rec_id(url)
+        if rec_id >= 0:
+            return redirect(url_for('bookmark.edit_view', id=rec_id))
+        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description))

--- a/bukuserver/bookmarklet.js
+++ b/bukuserver/bookmarklet.js
@@ -6,7 +6,7 @@
 
 var url = location.href;
 var title = document.title.trim() || "";
-var desc = document.getSelection().toString().trim();
+var desc = document.getSelection().toString().trim() || (document.querySelector('meta[name$=description i], meta[property$=description i]')||{}).content || "";
 if(desc.length > 4000){
     desc = desc.substr(0,4000) + '...';
     alert('The selected text is too long, it will be truncated.');

--- a/bukuserver/forms.py
+++ b/bukuserver/forms.py
@@ -16,7 +16,7 @@ class HomeForm(SearchBookmarksForm):
 
 
 class BookmarkForm(FlaskForm):
-    url = wtforms.StringField('Url', name='link', validators=[wtforms.validators.DataRequired()])
+    url = wtforms.StringField('Url', name='link', validators=[wtforms.validators.InputRequired()])
     title = wtforms.StringField()
     tags = wtforms.StringField()
     description = wtforms.TextAreaField()

--- a/bukuserver/forms.py
+++ b/bukuserver/forms.py
@@ -20,6 +20,7 @@ class BookmarkForm(FlaskForm):
     title = wtforms.StringField()
     tags = wtforms.StringField()
     description = wtforms.TextAreaField()
+    fetch = wtforms.HiddenField(filters=[bool])
 
 class ApiBookmarkForm(BookmarkForm):
     url = wtforms.StringField(validators=[wtforms.validators.DataRequired()])

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -67,6 +67,14 @@ def get_bool_from_env_var(key: str, default_value: bool) -> bool:
     return _BOOL_VALUES.get(os.getenv(key, '').lower(), default_value)
 
 
+def init_locale(app):
+    try:
+        from flask_babelex import Babel
+        Babel(app).localeselector(lambda: app.config['BUKUSERVER_LOCALE'])
+    except Exception:
+        app.logger.warning('failed to init locale')
+
+
 def create_app(db_file=None):
     """create app."""
     app = FlaskAPI(__name__)
@@ -97,8 +105,10 @@ def create_app(db_file=None):
         else:
             raise ImportError('Failed to import ReverseProxyPrefixFix')
     bukudb = BukuDb(dbfile=app.config['BUKUSERVER_DB_FILE'])
+    app.config['BUKUSERVER_LOCALE'] = os.getenv('BUKUSERVER_LOCALE') or 'en'
     app.app_context().push()
     setattr(flask.g, 'bukudb', bukudb)
+    init_locale(app)
 
     @app.shell_context_processor
     def shell_context():

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -1,21 +1,16 @@
 #!/usr/bin/env python
 # pylint: disable=wrong-import-order, ungrouped-imports
 """Server module."""
-import collections
 import os
 import sys
-import typing as T
-from typing import Any, Dict, Union  # NOQA; type: ignore
-from unittest import mock
+from typing import Union  # NOQA; type: ignore
 from urllib.parse import urlparse
 
 from flask.cli import FlaskGroup
-from flask.views import MethodView
 from flask_admin import Admin
-from flask_api import FlaskAPI, exceptions, status
+from flask_api import FlaskAPI, status
 from flask_bootstrap import Bootstrap
 
-import buku
 from buku import BukuDb, __version__, network_handler
 
 try:
@@ -34,27 +29,12 @@ from flask import (
 )
 
 try:
-    from . import forms, response, views
+    from . import api, response, views
 except ImportError:
-    from bukuserver import forms, response, views
+    from bukuserver import api, response, views
 
 
 STATISTIC_DATA = None
-
-response_ok = lambda: (jsonify(response.response_template['success']),
-                       status.HTTP_200_OK,
-                       {'ContentType': 'application/json'})
-response_bad = lambda: (jsonify(response.response_template['failure']),
-                        status.HTTP_400_BAD_REQUEST,
-                        {'ContentType': 'application/json'})
-to_response = lambda ok: response_ok() if ok else response_bad()
-
-
-def get_bukudb():
-    """get bukudb instance"""
-    db_file = current_app.config.get('BUKUSERVER_DB_FILE', None)
-    return BukuDb(dbfile=db_file)
-
 
 def handle_network():
     failed_resp = response.response_template['failure'], status.HTTP_400_BAD_REQUEST
@@ -72,13 +52,13 @@ def handle_network():
 
 
 def refresh_bookmark(rec_id: Union[int, None]):
-    result_flag = getattr(flask.g, 'bukudb', get_bukudb()).refreshdb(rec_id or 0, request.form.get('threads', 4))
-    return to_response(result_flag)
+    result_flag = getattr(flask.g, 'bukudb', api.get_bukudb()).refreshdb(rec_id or 0, request.form.get('threads', 4))
+    return api.to_response(result_flag)
 
 
 def get_tiny_url(rec_id):
-    url = getattr(flask.g, 'bukudb', get_bukudb()).tnyfy_url(rec_id)
-    return jsonify({'url': url}) if url else response_bad()
+    url = getattr(flask.g, 'bukudb', api.get_bukudb()).tnyfy_url(rec_id)
+    return jsonify({'url': url}) if url else api.response_bad()
 
 
 _BOOL_VALUES = {'true': True, '1': True, 'false': False, '0': False}
@@ -136,23 +116,23 @@ def create_app(db_file=None):
     )
     # routing
     #  api
-    tag_api_view = ApiTagView.as_view('tag_api')
+    tag_api_view = api.ApiTagView.as_view('tag_api')
     app.add_url_rule('/api/tags', defaults={'tag': None}, view_func=tag_api_view, methods=['GET'])
     app.add_url_rule('/api/tags/<tag>', view_func=tag_api_view, methods=['GET', 'PUT'])
-    bookmark_api_view = ApiBookmarkView.as_view('bookmark_api')
+    bookmark_api_view = api.ApiBookmarkView.as_view('bookmark_api')
     app.add_url_rule('/api/bookmarks', defaults={'rec_id': None}, view_func=bookmark_api_view, methods=['GET', 'POST', 'DELETE'])
     app.add_url_rule('/api/bookmarks/<int:rec_id>', view_func=bookmark_api_view, methods=['GET', 'PUT', 'DELETE'])
     app.add_url_rule('/api/bookmarks/refresh', 'refresh_bookmark', refresh_bookmark, defaults={'rec_id': None}, methods=['POST'])
     app.add_url_rule('/api/bookmarks/<int:rec_id>/refresh', 'refresh_bookmark', refresh_bookmark, methods=['POST'])
     app.add_url_rule('/api/bookmarks/<int:rec_id>/tiny', 'get_tiny_url', get_tiny_url, methods=['GET'])
     app.add_url_rule('/api/network_handle', 'network_handle', handle_network, methods=['POST'])
-    bookmark_range_api_view = ApiBookmarkRangeView.as_view('bookmark_range_api')
+    bookmark_range_api_view = api.ApiBookmarkRangeView.as_view('bookmark_range_api')
     app.add_url_rule(
         '/api/bookmarks/<int:starting_id>/<int:ending_id>',
         view_func=bookmark_range_api_view, methods=['GET', 'PUT', 'DELETE'])
-    bookmark_search_api_view = ApiBookmarkSearchView.as_view('bookmark_search_api')
+    bookmark_search_api_view = api.ApiBookmarkSearchView.as_view('bookmark_search_api')
     app.add_url_rule('/api/bookmarks/search', view_func=bookmark_search_api_view, methods=['GET', 'DELETE'])
-    bookmarklet_view = BookmarkletView.as_view('bookmarklet')
+    bookmarklet_view = api.BookmarkletView.as_view('bookmarklet')
     app.add_url_rule('/bookmarklet', view_func=bookmarklet_view, methods=['GET'])
 
     #  non api
@@ -167,258 +147,6 @@ def create_app(db_file=None):
     admin.add_view(views.StatisticView(
         bukudb, 'Statistic', endpoint='statistic'))
     return app
-
-
-def search_tag(
-    db: BukuDb, stag: T.Optional[str] = None, limit: T.Optional[int] = None
-) -> T.Tuple[T.List[str], T.Dict[str, int]]:
-    """search tag.
-
-    db:
-        buku db instance
-    stag:
-        search tag
-    limit:
-        positive integer limit
-
-    Returns
-    -------
-    tuple
-        list of unique tags sorted alphabetically and dictionary of tag and its usage count
-
-    Raises
-    ------
-    ValueError
-        if limit is not positive
-    """
-    if limit is not None and limit < 1:
-        raise ValueError("limit must be positive")
-    tags: T.Set[str] = set()
-    counter = collections.Counter()
-    query_list = ["SELECT DISTINCT tags , COUNT(tags) FROM bookmarks"]
-    if stag:
-        query_list.append("where tags LIKE :search_tag")
-    query_list.append("GROUP BY tags")
-    row: T.Tuple[str, int]
-    for row in db.cur.execute(" ".join(query_list), {"search_tag": f"%{stag}%"}):
-        for tag in row[0].strip(buku.DELIM).split(buku.DELIM):
-            if not tag:
-                continue
-            tags.add(tag)
-            counter[tag] += row[1]
-    return list(sorted(tags)), dict(counter.most_common(limit))
-
-
-class ApiTagView(MethodView):
-
-    def get(self, tag: T.Optional[str]):
-        bukudb = get_bukudb()
-        if tag is None:
-            return {"tags": search_tag(db=bukudb, limit=5)[0]}
-        tags = search_tag(db=bukudb, stag=tag)
-        if tag not in tags[1]:
-            raise exceptions.NotFound()
-        return dict(name=tag, usage_count=tags[1][tag])
-
-    def put(self, tag: str):
-        bukudb = get_bukudb()
-        try:
-            new_tags = request.data.get('tags')  # type: ignore
-            if new_tags:
-                new_tags = new_tags.split(',')
-            else:
-                return response_bad()
-        except AttributeError as e:
-            raise exceptions.ParseError(detail=str(e))
-        return to_response(bukudb.replace_tag(tag, new_tags))
-
-
-class ApiBookmarkView(MethodView):
-
-    def get(self, rec_id: Union[int, None]):
-        if rec_id is None:
-            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-            all_bookmarks = bukudb.get_rec_all()
-            result = {'bookmarks': []}  # type: Dict[str, Any]
-            for bookmark in all_bookmarks:
-                result_bookmark = {
-                    'url': bookmark[1],
-                    'title': bookmark[2],
-                    'tags': [x for x in bookmark[3].split(',') if x],
-                    'description': bookmark[4]
-                }
-                if not request.path.startswith('/api/'):
-                    result_bookmark['id'] = bookmark[0]
-                result['bookmarks'].append(result_bookmark)
-            res = jsonify(result)
-        else:
-            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-            bookmark = bukudb.get_rec_by_id(rec_id)
-            if bookmark is None:
-                res = response_bad()
-            else:
-                res = jsonify({
-                    'url': bookmark[1],
-                    'title': bookmark[2],
-                    'tags': [x for x in bookmark[3].split(',') if x],
-                    'description': bookmark[4]
-                })
-        return res
-
-    def post(self, rec_id: None = None):
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        create_bookmarks_form = forms.ApiBookmarkForm()
-        url_data = create_bookmarks_form.url.data
-        result_flag = bukudb.add_rec(
-            url_data,
-            create_bookmarks_form.title.data,
-            create_bookmarks_form.tags.data,
-            create_bookmarks_form.description.data
-        )
-        return to_response(result_flag != -1)
-
-    def put(self, rec_id: int):
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        result_flag = bukudb.update_rec(
-            rec_id,
-            request.form.get('url'),
-            request.form.get('title'),
-            request.form.get('tags'),
-            request.form.get('description'))
-        return to_response(result_flag)
-
-    def delete(self, rec_id: Union[int, None]):
-        if rec_id is None:
-            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-            with mock.patch('buku.read_in', return_value='y'):
-                result_flag = bukudb.cleardb()
-        else:
-            bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-            result_flag = bukudb.delete_rec(rec_id)
-        return to_response(result_flag)
-
-
-class ApiBookmarkRangeView(MethodView):
-
-    def get(self, starting_id: int, ending_id: int):
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        max_id = bukudb.get_max_id()
-        if starting_id > max_id or ending_id > max_id:
-            return response_bad()
-        result = {'bookmarks': {}}  # type: ignore
-        for i in range(starting_id, ending_id + 1, 1):
-            bookmark = bukudb.get_rec_by_id(i)
-            result['bookmarks'][i] = {
-                'url': bookmark[1],
-                'title': bookmark[2],
-                'tags': [x for x in bookmark[3].split(',') if x],
-                'description': bookmark[4]
-            }
-        return jsonify(result)
-
-    def put(self, starting_id: int, ending_id: int):
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        max_id = bukudb.get_max_id()
-        if starting_id > max_id or ending_id > max_id:
-            return response_bad()
-        for i in range(starting_id, ending_id + 1, 1):
-            updated_bookmark = request.data.get(str(i))  # type: ignore
-            result_flag = bukudb.update_rec(
-                i,
-                updated_bookmark.get('url'),
-                updated_bookmark.get('title'),
-                updated_bookmark.get('tags'),
-                updated_bookmark.get('description'))
-            if result_flag is False:
-                return response_bad()
-        return response_ok()
-
-    def delete(self, starting_id: int, ending_id: int):
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        max_id = bukudb.get_max_id()
-        if starting_id > max_id or ending_id > max_id:
-            return response_bad()
-        idx = min([starting_id, ending_id])
-        result_flag = bukudb.delete_rec(idx, starting_id, ending_id, is_range=True)
-        return to_response(result_flag)
-
-
-class ApiBookmarkSearchView(MethodView):
-
-    def get(self):
-        arg_obj = request.args
-        keywords = arg_obj.getlist('keywords')
-        all_keywords = arg_obj.get('all_keywords')
-        deep = arg_obj.get('deep')
-        regex = arg_obj.get('regex')
-        # api request is more strict
-        all_keywords = False if all_keywords is None else all_keywords
-        deep = False if deep is None else deep
-        regex = False if regex is None else regex
-        all_keywords = (
-            all_keywords if isinstance(all_keywords, bool) else
-            all_keywords.lower() == 'true'
-        )
-        deep = deep if isinstance(deep, bool) else deep.lower() == 'true'
-        regex = regex if isinstance(regex, bool) else regex.lower() == 'true'
-
-        result = {'bookmarks': []}
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        found_bookmarks = bukudb.searchdb(keywords, all_keywords, deep, regex)
-        found_bookmarks = [] if found_bookmarks is None else found_bookmarks
-        res = None
-        if found_bookmarks is not None:
-            for bookmark in found_bookmarks:
-                result_bookmark = {
-                    'id': bookmark[0],
-                    'url': bookmark[1],
-                    'title': bookmark[2],
-                    'tags': list(filter(lambda x: x, bookmark[3].split(','))),
-                    'description': bookmark[4]
-                }
-                result['bookmarks'].append(result_bookmark)
-        current_app.logger.debug('total bookmarks:{}'.format(len(result['bookmarks'])))
-        res = jsonify(result)
-        return res
-
-    def delete(self):
-        arg_obj = request.form
-        keywords = arg_obj.getlist('keywords')
-        all_keywords = arg_obj.get('all_keywords')
-        deep = arg_obj.get('deep')
-        regex = arg_obj.get('regex')
-        # api request is more strict
-        all_keywords = False if all_keywords is None else all_keywords
-        deep = False if deep is None else deep
-        regex = False if regex is None else regex
-        all_keywords = (
-            all_keywords if isinstance(all_keywords, bool) else
-            all_keywords.lower() == 'true'
-        )
-        deep = deep if isinstance(deep, bool) else deep.lower() == 'true'
-        regex = regex if isinstance(regex, bool) else regex.lower() == 'true'
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        found_bookmarks = bukudb.searchdb(keywords, all_keywords, deep, regex)
-        found_bookmarks = [] if found_bookmarks is None else found_bookmarks
-        res = None
-        if found_bookmarks is not None:
-            for bookmark in found_bookmarks:
-                if not bukudb.delete_rec(bookmark[0]):
-                    res = response_bad()
-        return res or response_ok()
-
-
-class BookmarkletView(MethodView):  # pylint: disable=too-few-public-methods
-    def get(self):
-        url = request.args.get('url')
-        title = request.args.get('title')
-        description = request.args.get('description')
-
-        bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-        rec_id = bukudb.get_rec_id(url)
-        if rec_id >= 0:
-            return redirect(url_for('bookmark.edit_view', id=rec_id))
-        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description))
 
 
 class CustomFlaskGroup(FlaskGroup):  # pylint: disable=too-few-public-methods

--- a/bukuserver/static/bukuserver/js/flash.js
+++ b/bukuserver/static/bukuserver/js/flash.js
@@ -1,4 +1,4 @@
 $(document).ready(function () {
   SAVED && $(`.alert-success`).first().html((_, s) =>
-    s.replace(/(<\/button>)([^]*)$/, `$1<a href="details?id=${SAVED}">$2</a>`));
+    s.replace(/(<\/button>)([^]*)$/, `$1<a href="/${location.pathname.match(/[^/]+/)}/details?id=${SAVED}">$2</a>`));
 });

--- a/bukuserver/static/bukuserver/js/flash.js
+++ b/bukuserver/static/bukuserver/js/flash.js
@@ -1,4 +1,0 @@
-$(document).ready(function () {
-  SAVED && $(`.alert-success`).first().html((_, s) =>
-    s.replace(/(<\/button>)([^]*)$/, `$1<a href="/${location.pathname.match(/[^/]+/)}/details?id=${SAVED}">$2</a>`));
-});

--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -4,6 +4,7 @@
 {% block tail %}
   {{ super() }}
   {{ buku.script('bookmark.js') }}
+  {{ buku.fetch_checkbox() }}
   {{ buku.link_saved() }}
   {{ buku.limit_navigation_if_popup() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -1,11 +1,9 @@
 {% extends 'admin/model/create.html' %}
-
-{% block head %}
-  {{ super() }}
-  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
-{% endblock %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block tail %}
   {{ super() }}
-  <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>
+  {{ buku.script('bookmark.js') }}
+  {{ buku.link_saved() }}
+  {{ buku.limit_navigation_if_popup() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_create_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_create_modal.html
@@ -10,4 +10,5 @@
 {% block tail %}
   {{ super() }}
   {{ buku.script('bookmark.js') }}
+  {{ buku.fetch_checkbox() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_create_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_create_modal.html
@@ -1,4 +1,5 @@
 {% extends 'admin/model/modals/create.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block create_form %}
   {{ lib.render_form(form, return_url, lib.extra(), form_opts=form_opts,
@@ -8,5 +9,5 @@
 
 {% block tail %}
   {{ super() }}
-  <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>
+  {{ buku.script('bookmark.js') }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -1,15 +1,9 @@
 {% extends 'admin/model/details.html' %}
-
-{% block head %}
-  {{ super() }}
-  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
-{% endblock %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block tail %}
   {{ super() }}
-  <script>{
-    let target = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
-    $(`td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'))
-    $(`td:contains("Url") + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${target}>${s}</a>`);
-  }</script>
+  {{ buku.details_formatting() }}
+  {{ buku.link_saved() }}
+  {{ buku.limit_navigation_if_popup() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_details_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_details_modal.html
@@ -1,10 +1,7 @@
 {% extends 'admin/model/modals/details.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block tail %}
   {{ super() }}
-  <script>{
-    let target = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
-    $(`.modal td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'))
-    $(`.modal td:contains("Url") + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${target}>${s}</a>`);
-  }</script>
+  {{ buku.details_formatting('.modal') }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_edit.html
+++ b/bukuserver/templates/bukuserver/bookmark_edit.html
@@ -1,8 +1,8 @@
 {% extends 'admin/model/edit.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block head %}
   {{ super() }}
-  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
 {% endblock %}
 
 {% block edit_form %}
@@ -21,6 +21,8 @@
 
 {% block tail %}
   {{ super() }}
-  <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>
+  {{ buku.script('bookmark.js') }}
+  {{ buku.link_saved() }}
+  {{ buku.limit_navigation_if_popup() }}
   <script>$('.submit-row').append($('.delete-form'))</script>
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_edit_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_edit_modal.html
@@ -1,6 +1,7 @@
 {% extends 'admin/model/modals/edit.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block tail %}
   {{ super() }}
-  <script src="{{ url_for('static', filename='bukuserver/js/bookmark.js') }}"></script>
+  {{ buku.script('bookmark.js') }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmarks_list.html
+++ b/bukuserver/templates/bukuserver/bookmarks_list.html
@@ -1,7 +1,12 @@
 {% extends 'admin/model/list.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block head %}
   {{ super() }}
-  <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
-  <script>close(); /* closes if in popup window */</script>
+  {{ buku.close_if_popup() }}
+{% endblock %}
+
+{% block tail %}
+  {{ super() }}
+  {{ buku.link_saved() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmarks_list.html
+++ b/bukuserver/templates/bukuserver/bookmarks_list.html
@@ -3,4 +3,5 @@
 {% block head %}
   {{ super() }}
   <script>const SAVED = '{{ session.pop('saved', '') }}'</script>
+  <script>close(); /* closes if in popup window */</script>
 {% endblock %}

--- a/bukuserver/templates/bukuserver/home.html
+++ b/bukuserver/templates/bukuserver/home.html
@@ -1,8 +1,9 @@
 {% extends "admin/index.html" %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block head %}
   {{ super() }}
-  <script>close(); /* closes if in popup window */</script>
+  {{ buku.close_if_popup() }}
 {% endblock %}
 
 {% block menu_links %}

--- a/bukuserver/templates/bukuserver/home.html
+++ b/bukuserver/templates/bukuserver/home.html
@@ -1,5 +1,10 @@
 {% extends "admin/index.html" %}
 
+{% block head %}
+  {{ super() }}
+  <script>close(); /* closes if in popup window */</script>
+{% endblock %}
+
 {% block menu_links %}
 {{ super() }}
 <form class="navbar-form navbar-right" action="{{url_for('bookmark.index_view')}}" method="GET">
@@ -37,9 +42,10 @@
     <div class=" col-md-4 col-md-offset-4">
       <p style="padding: 2em"> Bookmarklet:
 	<a title="Drag this link to your bookmarks toolbar"
-	   href="javascript:void%20function(){var%20e=location.href,t=document.title.trim()||%22%22,o=document.getSelection().toString().trim();o.length%3E4e3%26%26(o=o.substr(0,4e3)+%22...%22,alert(%22The%20selected%20text%20is%20too%20long,%20it%20will%20be%20truncated.%22)),e=%22{{url_for("bookmarklet",_external=True)}}%3Furl=%22+encodeURIComponent(e)+%22%26title=%22+encodeURIComponent(t)+%22%26description=%22+encodeURIComponent(o),window.open(e,%22_blank%22,%22menubar=no,%20height=600,%20width=600,%20toolbar=no,%20scrollbars=yes,%20status=no,%20dialog=1%22)}();">
+	   href="javascript:void%20function(){var%20e=location.href,t=document.title.trim()||%22%22,o=document.getSelection().toString().trim()||(document.querySelector(%22meta[name$=description%20i],%20meta[property$=description%20i]%22)||{}).content||%22%22;o.length%3E4e3%26%26(o=o.substr(0,4e3)+%22...%22,alert(%22The%20selected%20text%20is%20too%20long,%20it%20will%20be%20truncated.%22)),e=%22{{url_for("bookmarklet",_external=True)}}%3Furl=%22+encodeURIComponent(e)+%22%26title=%22+encodeURIComponent(t)+%22%26description=%22+encodeURIComponent(o),window.open(e,%22_blank%22,%22menubar=no,%20height=600,%20width=600,%20toolbar=no,%20scrollbars=yes,%20status=no,%20dialog=1%22)}();">
 	  <b>✚ Add to Buku</b>
-	</a>
+	</a><br/>
+        <em style="font-size: smaller">Note: if you select text on the page before activating the bookmarklet, it'll be used as description instead of page metadata.</em>
       </p>
     </div>
   </div>

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -17,6 +17,15 @@
   <script>opener && (opener !== window) && document.body.classList.add('popup')</script>
 {% endmacro %}
 
+{% macro fetch_checkbox(checked=True) %}
+  <script>
+    $('.admin-form [name=fetch]').remove();
+    $('.admin-form').append(
+      $(`<label class="form-group" style="display: block"><span class="col-md-2 text-right">{{ _gettext('Fetch') }}</span>`
+        +`<span class="col-md-10"><input type="checkbox" name="fetch"{% if checked %} checked{% endif %}></span></label>`))
+  </script>
+{% endmacro %}
+
 {% macro details_formatting(prefix='') %}
   <script>{
     const TARGET = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -30,7 +30,9 @@
   <script>{
     const TARGET = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
     $(`{{prefix}} td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'));
+    {% if session.pop('netloc', None) %}
     $(`{{prefix}} td:contains({{ _gettext('Url') | tojson }}) + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${TARGET}>${s}</a>`);
+    {% endif %}
   }</script>
 {% endmacro %}
 

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -1,0 +1,39 @@
+{% macro filter(name, value) %}{{ url_for('bookmark.index_view', **{'flt0_'+name: value}) }}{% endmacro %}
+
+{% macro script(filename) %}
+  <script src="{{ url_for('static', filename='bukuserver/js/'+filename) }}"></script>
+{% endmacro %}
+
+{% macro close_if_popup() %}
+  <script>close(); /* closes if in popup window */</script>
+{% endmacro %}
+
+{% macro limit_navigation_if_popup() %}
+  <style>
+    .popup .navbar-brand {pointer-events: none}
+    .popup :is(#admin-navbar-collapse, .navbar-toggle) {display: none !important}
+    .popup .nav-tabs :is(:first-child, :nth-child(2):not(.active)) > * {display: none}
+  </style>
+  <script>opener && (opener !== window) && document.body.classList.add('popup')</script>
+{% endmacro %}
+
+{% macro details_formatting(prefix='') %}
+  <script>{
+    const TARGET = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
+    $(`{{prefix}} td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'));
+    $(`{{prefix}} td:contains({{ _gettext('Url') | tojson }}) + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${TARGET}>${s}</a>`);
+  }</script>
+{% endmacro %}
+
+{% macro link_saved() %}
+  {% set backlink = request.args.get('url', request.full_path) %}
+  {% set saved = session.pop('saved', None) %}
+  {% if saved %}
+  <script>{
+    const SUCCESS = [{{ _gettext('Record was successfully created.') | tojson }},
+                     {{ _gettext('Record was successfully saved.') | tojson }}];
+    $(`.alert-success`).filter((idx, e) => SUCCESS.some(s => e.innerText.includes(s))).html((_, s) =>
+      s.replace(/(<\/button>)([^]*)$/, `$1<a href="{{ url_for('.details_view', id=saved, url=backlink) }}">$2</a>`));
+  }</script>
+  {% endif %}
+{% endmacro %}

--- a/bukuserver/templates/bukuserver/statistic.html
+++ b/bukuserver/templates/bukuserver/statistic.html
@@ -1,5 +1,10 @@
 {% extends "bukuserver/home.html" %}
 
+{% block head %}
+  {{ super() }}
+  <script>close(); /* closes if in popup window */</script>
+{% endblock %}
+
 {% block body %}
 <div class="container">
   <form class="form-inline" action="{{url_for('statistic.index')}}" method="POST">

--- a/bukuserver/templates/bukuserver/statistic.html
+++ b/bukuserver/templates/bukuserver/statistic.html
@@ -1,8 +1,9 @@
 {% extends "bukuserver/home.html" %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block head %}
   {{ super() }}
-  <script>close(); /* closes if in popup window */</script>
+  {{ buku.close_if_popup() }}
 {% endblock %}
 
 {% block body %}
@@ -34,7 +35,7 @@
       {% for item, number, _ in most_common_netlocs %}
       <tr>
         <td>{{loop.index}}</td>
-        <td> <a href="{{url_for('bookmark.index_view', flt0_url_netloc_match=item)}}">{{item}}</a> </td>
+        <td> <a href="{{buku.filter('url_netloc_match', item)}}">{{item}}</a> </td>
         <td class="text-right">{{number}}</td>
       </tr>
       {% endfor %}
@@ -65,7 +66,7 @@
                 <td>{{loop.index}}</td>
                 <td>
                   {% if item %}
-                  <a href="{{url_for('bookmark.index_view', flt0_url_netloc_match=item)}}">{{item}}</a>
+                  <a href="{{buku.filter('url_netloc_match', item)}}">{{item}}</a>
                   {% else %}
                   <span class="btn btn-default" disabled="disabled">(No Netloc)</span>
                   {% endif %}
@@ -104,7 +105,7 @@
       <tr>
         <td>{{loop.index}}</td>
         <td>
-          <a href="{{url_for('bookmark.index_view', flt0_tags_contain=item)}}">{{item}}</a>
+          <a href="{{buku.filter('tags_contain', item)}}">{{item}}</a>
         </td>
         <td class="text-right">{{number}}</td>
       </tr>
@@ -121,7 +122,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title" id="myModalLabel">Netloc ranking</h4>
+          <h4 class="modal-title" id="myModalLabel">Tag ranking</h4>
         </div>
         <div class="modal-body">
           <table class="table table-condensed">
@@ -133,7 +134,7 @@
             {% for item, number in tag_counter.most_common() %}
               <tr>
                 <td>{{loop.index}}</td>
-                <td> <a href="{{url_for('bookmark.index_view', flt0_tags_contain=item)}}">{{item}}</a> </td>
+                <td> <a href="{{buku.filter('tags_contain', item)}}">{{item}}</a> </td>
                 <td class="text-right">{{number}}</td>
               </tr>
             {% endfor %}
@@ -168,7 +169,7 @@
         <td>{{loop.index}}</td>
         <td>
           {% if item %}
-          <a href="{{url_for('bookmark.index_view', flt0_title_equals=item)}}">{{item}}</a>
+          <a href="{{buku.filter('title_equals', item)}}">{{item}}</a>
           {% else %}
           (No Title)
           {% endif %}
@@ -203,7 +204,7 @@
                 <td>{{loop.index}}</td>
                 <td style="word-break:break-all;">
                   {% if item %}
-                  <a href="{{url_for('bookmark.index_view', flt0_title_equals=item)}}">{{item}}</a>
+                  <a href="{{buku.filter('title_equals', item)}}">{{item}}</a>
                   {% else %}
                   <span class="btn btn-default" disabled="disabled">(No Title)</span>
                   {% endif %}
@@ -222,7 +223,7 @@
 
 {% block tail %}
   {{ super() }}
-  <script src="{{url_for('static', filename='bukuserver/js/Chart.js')}}"></script>
+  {{ buku.script('Chart.js') }}
   <script>
   var netlocCtx = document.getElementById("mostCommonChart").getContext('2d');
   var netlocChart = new Chart(netlocCtx, {
@@ -242,7 +243,8 @@
       ]
     },
     options: {
-      'onClick' : function (evt, item) {
+      onClick (evt, item) {
+        if (!item[0]) return;
         var value = this.data.labels[item[0]._index];
         var form = $('<form></form>');
 
@@ -282,7 +284,8 @@
       ]
     },
     options: {
-      'onClick' : function (evt, item) {
+      onClick (evt, item) {
+        if (!item[0]) return;
         var tagStr = this.data.labels[item[0]._index];
         var url = "{{url_for('bookmark.index_view')}}?flt0_tags_contain=" + encodeURIComponent(tagStr);
         window.location.href = url;
@@ -308,7 +311,8 @@
       ]
     },
     options: {
-      'onClick' : function (evt, item) {
+      onClick (evt, item) {
+        if (!item[0]) return;
         var value = this.data.labels[item[0]._index];
         var form = $('<form></form>');
 

--- a/bukuserver/templates/bukuserver/tags_list.html
+++ b/bukuserver/templates/bukuserver/tags_list.html
@@ -1,8 +1,9 @@
 {% extends 'admin/model/list.html' %}
+{% import 'bukuserver/lib.html' as buku with context %}
 
 {% block head %}
   {{ super() }}
-  <script>close(); /* closes if in popup window */</script>
+  {{ buku.close_if_popup() }}
 {% endblock %}
 
 {% block model_menu_bar_before_filters %}

--- a/bukuserver/templates/bukuserver/tags_list.html
+++ b/bukuserver/templates/bukuserver/tags_list.html
@@ -1,5 +1,10 @@
 {% extends 'admin/model/list.html' %}
 
+{% block head %}
+  {{ super() }}
+  <script>close(); /* closes if in popup window */</script>
+{% endblock %}
+
 {% block model_menu_bar_before_filters %}
   {{ super() }}
   <form id="refresh" style="display:none" method="POST" action="refresh"></form>

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -185,13 +185,13 @@ class BookmarkModelView(BaseModelView):
 
     def create_model(self, form):
         try:
-            model = types.SimpleNamespace(id=None, url=None, title=None, tags=None, description=None)
+            model = types.SimpleNamespace(id=None, url=None, title=None, tags=None, description=None, fetch=True)
             form.populate_obj(model)
             vars(model).pop("id")
             self._on_model_change(form, model, True)
             if not model.url.strip():
                 raise ValueError(f"url invalid: {model.url}")
-            kwargs = {"url": model.url}
+            kwargs = {'url': model.url, 'fetch': model.fetch}
             if model.tags.strip():
                 kwargs["tags_in"] = buku.parse_tags([model.tags])
             for key, item in (("title_in", model.title), ("desc", model.description)):

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -161,7 +161,7 @@ class BookmarkModelView(BaseModelView):
     edit_template = "bukuserver/bookmark_edit.html"
     named_filter_urls = True
     extra_css = ['/static/bukuserver/css/bookmark.css']
-    extra_js = ['/static/bukuserver/js/' + it for it in ('page_size.js', 'last_page.js', 'flash.js')]
+    extra_js = ['/static/bukuserver/js/' + it for it in ('page_size.js', 'last_page.js')]
     last_page = expose('/last-page')(last_page)
 
     def __init__(self, *args, **kwargs):

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -109,7 +109,7 @@ class BookmarkModelView(BaseModelView):
             )
         tag_text_markup = "".join(tag_text)
         description = model.description and br_tag.join(map(escape, model.description.split('\n')))
-        if not netloc and not parsed_url.scheme:
+        if not netloc:
             return Markup(br_tag.join([escape(model.title), escape(model.url), tag_text_markup, description]))
         res = []
         if not current_app.config.get("BUKUSERVER_DISABLE_FAVICON", False) and netloc:
@@ -189,7 +189,7 @@ class BookmarkModelView(BaseModelView):
             form.populate_obj(model)
             vars(model).pop("id")
             self._on_model_change(form, model, True)
-            if not model.url.strip():
+            if not model.url:
                 raise ValueError(f"url invalid: {model.url}")
             kwargs = {'url': model.url, 'fetch': model.fetch}
             if model.tags.strip():
@@ -282,6 +282,8 @@ class BookmarkModelView(BaseModelView):
                 setattr(bm_sns, field.name.lower(), value.replace(',', ', '))
             else:
                 setattr(bm_sns, field.name.lower(), bookmark[field.value])
+            if field == BookmarkField.URL:
+                session['netloc'] = urlparse(bookmark[field.value]).netloc
         return bm_sns
 
     def get_pk_value(self, model):


### PR DESCRIPTION
Several commits with co-dependent code.

fixes #639:
* preventing override of POST data by URL arguments in `create_form()`
* adding metadata collection to the bookmarklet (when no text is selected)
* implementing a checkbox allowing to disable automatic fetching of empty fields (placed under the submit buttons)
* fixing saved link in the success alert (so that it works correctly in the form page)
* automatically closing any of the primary pages if opened in popup window (so that it works like a modal dialog)
* hiding/blocking primary page links in popup window (in the "refactoring" commit)
* handling DB rejection in `create_model()` (producing custom error message)

fixes #642:
* disabling hyperlinks for URLs without netloc (in list & details)  
  _note: URL parser works differently in JS, so I'm using the netloc value calculated in Python_
* changing URL check on create from "blank" to "empty"

also:
* handling nonexistent ID in `get_one()`, as suggested in #639
* including a temporary file created by tests into gitignore
* moving API implementation into a separate file, as suggested in #637 (put as a separate commit for clarity)
* improving wording in bukuserver readme (configuration section)
* removing JSON response code duplication (detected by linter after separating API)
* simplifying `get_bool_from_env_var()` (and documenting valid inputs in readme)
* fixing tags modal title & JS error in statistic page (the latter occurs when clicking outside of a pie chart)
* improving saved link message detection & adding a backlink to it (so that the "list" link & form submit redirect to previous page)  
  _note: there's [an upstream bug occurring in certain circumstances](https://github.com/flask-admin/flask-admin/issues/2311) which breaks backlink logic; I suggest waiting for an upstream fix rather than trying to work around it_
* moving duplicate logic in templates (+`flash.js`) out into a macro library
* implementing partial l10n support (via env variable) in case someone wants it (there's code that accounts for l10n but no easy way to test it out)