### PR TITLE
Bugfix/window setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,14 @@ reverse_proxy = " ".join(
         "https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.2rc1.zip",
     ]
 )
+install_requires = [
+    'beautifulsoup4>=4.4.1',
+    'certifi',
+    'cryptography>=1.2.3',
+    'html5lib>=1.0.1',
+    'pyreadline; sys_platform == \'windows\'',
+    'urllib3>=1.23',
+]
 
 setup(
     name='buku',
@@ -63,19 +71,13 @@ setup(
     python_requires='>=3.7',  # requires pip>=9.0.0
     platforms=['any'],
     py_modules=['buku'],
-    install_requires=[
-        'beautifulsoup4>=4.4.1',
-        'cryptography>=1.2.3',
-        'urllib3>=1.23',
-        'html5lib>=1.0.1',
-    ],
+    install_requires=install_requires,
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     entry_points={
         'console_scripts': ['buku=buku:main', 'bukuserver=bukuserver.server:cli']
     },
     extras_require={
-        "ca-certificates": ["certifi"],
         "tests": tests_require + server_require + [reverse_proxy],
         "server": server_require,
         "reverse_proxy": [reverse_proxy],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ reverse_proxy = " ".join(
     [
         "flask-reverse-proxy-fix",
         "@",
-        "https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.2.zip",
+        "https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.3.zip",
     ]
 )
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ reverse_proxy = " ".join(
     [
         "flask-reverse-proxy-fix",
         "@",
-        "https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.2rc1.zip",
+        "https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.2.zip",
     ]
 )
 install_requires = [

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,15 +1,32 @@
 import pathlib
 
+import pytest
 
-def test_bukuserver_requirement(monkeypatch):
-    def m_setup(**kwargs):
+
+@pytest.fixture
+def setup_obj(monkeypatch):
+    def m_setup(**_):
         return None
     import setuptools
     monkeypatch.setattr(setuptools, 'setup', m_setup)
     import setup
 
+    return setup
+
+
+def test_bukuserver_requirement(setup_obj):
     assert [
         x
         for x in pathlib.Path("bukuserver/requirements.txt").read_text(encoding="utf8", errors="surrogateescape").splitlines()
         if "flask-reverse-proxy-fix" not in x
-    ] == setup.server_require
+    ] == setup_obj.server_require
+
+
+def test_buku_requirement(setup_obj):
+    assert sorted(
+        [
+            x
+            for x in pathlib.Path("requirements.txt").read_text(encoding="utf8", errors="surrogateescape").splitlines()
+            if not x.startswith('#') and x != 'setuptools'
+        ]
+    ) == sorted(setup_obj.install_requires)


### PR DESCRIPTION
1. test install_require setup so it is similar to requirements.txt
2. certifi is required and not optional anymore based on requirements.txt
3. pyreadline3 is required on window based on requirements.txt
4. flask-reverse-proxy is use latest version (only version bump to satisfy test)

fixes https://github.com/jarun/buku/issues/664