### PR TITLE
[bukuserver] Escaping markup

### DIFF
--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -428,18 +428,9 @@ class TagModelView(BaseModelView):
 
     def _name_formatter(self, _, model, name):
         data = getattr(model, name)
-        if not data:
-            return Markup(
-                '<a href="{}">{}</a>'.format(
-                    url_for("bookmark.index_view", flt2_tags_number_equal=0),
-                    "&lt;EMPTY TAG&gt;",
-                )
-            )
-        return Markup(
-            '<a href="{}">{}</a>'.format(
-                url_for("bookmark.index_view", flt1_tags_contain=data), data
-            )
-        )
+        query, title = (({'flt0_tags_contain': data}, data) if data else
+                        ({'flt0_tags_number_equal': 0}, '<EMPTY TAG>'))
+        return Markup(f'<a href="{escape(url_for("bookmark.index_view", **query))}">{escape(title)}</a>')
 
     can_create = False
     can_set_page_size = True


### PR DESCRIPTION
The data rendered on page should be escaped to avoid evaluating it as HTML (and potentially JS)