### PR TITLE
allow spaces in bookmark.js

### DIFF
--- a/bukuserver/static/bukuserver/js/bookmark.js
+++ b/bukuserver/static/bukuserver/js/bookmark.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $.getJSON( "/api/tags", function( json ) {
     $('input#tags').select2({
       tags: json.tags,
-      tokenSeparators: [','],
+      tokenSeparators: [',', ' '],
     });
   });
 });


### PR DESCRIPTION
Allow using spaces as tag seperators.
Useful when copy pasting tags from a github repo, even a stackoverflow post tags.

Side Effects:
- Maybe if people are using spaces in tags (not sure if it is even allowed) they will get affected