### PR TITLE
fixed CI pylint & Python 3.11 testing runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ lint-template: &lint-template
 jobs:
   lint:
     docker:
-      - image: python:3.7-slim
+      - image: python:3.11-slim
     <<: *lint-template
 
   py38:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ buku.py
 /tests/vcr_cassettes/test_search_and_open_all_in_browser.yaml
 /tests/vcr_cassettes/tests.test_bukuDb/
 /bookmarks.db
+/venv/

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -971,7 +971,7 @@ def test_delete_rec_range_and_delay_commit(
         [100, False, True],
     ],
 )
-def test_delete_rec_index_and_delay_commit(index, delay_commit, input_retval):
+def test_delete_rec_index_and_delay_commit(setup, index, delay_commit, input_retval):
     """test delete rec, index and delay commit."""
     bdb = BukuDb()
     bdb_dc = BukuDb()  # instance for delay_commit check.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python37,python38,python39,python310,pylint,flake8
+envlist = python38,python39,python310,python311,pylint,flake8
 
 [flake8]
 max-line-length = 139
@@ -35,11 +35,6 @@ ignore =
 usedevelop = true
 deps = pytest
 
-[testenv:python37]
-extras = tests
-commands =
-    pytest --cov buku -vv -m "not non_tox" {posargs}
-
 [testenv:python38]
 extras = tests
 commands =
@@ -55,12 +50,19 @@ extras = tests
 commands =
     pytest --cov buku -vv -m "not non_tox" {posargs}
 
+[testenv:python311]
+extras = tests
+commands =
+    pytest --cov buku -vv -m "not non_tox" {posargs}
+
 [testenv:pylint]
+basepython = py311
 deps = pylint
 commands =
     pylint . --rc-file tests/.pylintrc --recursive yes --ignore-paths .tox/,build/,venv/
 
 [testenv:flake8]
+basepython = py311
 deps = flake8
 commands =
     python -m flake8


### PR DESCRIPTION
As per discussion [here](https://github.com/jarun/buku/commit/aa3606d4f2760350706ae5ae97a65cd015d20215#commitcomment-125638115).

`pylint` fails due to being run on Python 3.7 image (there might be a bug in `pip` involved, as it delves into an infinite recursion when trying to resolve deps, but ultimately it shouldn't be run on an outdated runtime in the first place).

Unit tests seem to be failing due to conflicting DB file access. Using the `setup` fixture appears to resolve the immediate issue, but I strongly suggest switching as many tests as possible to an [in-memory DB](https://www.sqlite.org/inmemorydb.html) (this can be supported by setting custom logic for `dbfile == ''` in `BukuDb.initdb()`, then simply making a fixture that produces `BukuDb(dbfile='')`).