### PR TITLE
[bukuserver] added support for flask-babel

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -132,6 +132,8 @@ Note: Valid boolean values are `true`, `false`, `1`, `0` (case-insensitive).
 
 Note: if input is invalid, the default value will be used if defined
 
+Note: `BUKUSERVER_LOCALE` requires either `flask_babel` or `flask_babelex` installed
+
 e.g. to set bukuserver to show 100 item per page run the following command
 
 ```

--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.2.2
-Flask-Admin>=1.6.0
+Flask-Admin>=1.6.1
 Flask-API>=3.0.post1
 Flask-Bootstrap>=3.3.7.1
 flask-paginate>=2022.1.8

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -68,9 +68,13 @@ def get_bool_from_env_var(key: str, default_value: bool) -> bool:
 
 
 def init_locale(app):
-    try:
-        from flask_babelex import Babel
-        Babel(app).localeselector(lambda: app.config['BUKUSERVER_LOCALE'])
+    try:  # as per Flask-Admin-1.6.1
+        try:
+            from flask_babelex import Babel
+            Babel(app).localeselector(lambda: app.config['BUKUSERVER_LOCALE'])
+        except ImportError:
+            from flask_babel import Babel
+            Babel().init_app(app, locale_selector=lambda: app.config['BUKUSERVER_LOCALE'])
     except Exception:
         app.logger.warning('failed to init locale')
 

--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,13 @@ tests_require = [
     'setuptools>=41.0.1',
     'vcrpy>=1.13.0',
     'lxml',
-    'flask_babelex',
-    'pytz',
+    'flask_babel',
 ]
 
 
 server_require = [
     "arrow>=1.2.2",
-    "Flask-Admin>=1.6.0",
+    "Flask-Admin>=1.6.1",
     "Flask-API>=3.0.post1",
     "Flask-Bootstrap>=3.3.7.1",
     "flask-paginate>=2022.1.8",


### PR DESCRIPTION
Updating `BUKUSERVER_LOCALE` support to match [the latest release of flask-admin](https://github.com/flask-admin/flask-admin/blob/v1.6.1/flask_admin/babel.py#L2-L5)