### PR TITLE
[jarun#698] fixed dependencies & improved testing time

### DIFF
--- a/buku
+++ b/buku
@@ -3969,17 +3969,17 @@ def network_handler(
     except Exception as e:
         LOGERR('network_handler(): %s', e)
         exception = True
-    finally:
-        if manager:
-            manager.clear()
-        if exception:
-            return (None, None, None, 0, 0)
-        if method == 'HEAD':
-            return ('', '', '', 1, 0)
-        if page_title is None:
-            return ('', page_desc, page_keys, 0, 0)
 
-        return (page_title, page_desc, page_keys, 0, 0)
+    if manager:
+        manager.clear()
+    if exception:
+        return (None, None, None, 0, 0)
+    if method == 'HEAD':
+        return ('', '', '', 1, 0)
+    if page_title is None:
+        return ('', page_desc, page_keys, 0, 0)
+
+    return (page_title, page_desc, page_keys, 0, 0)
 
 
 def parse_tags(keywords=[]):
@@ -4210,8 +4210,7 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
                 print_single_rec(row, count, columns)
         except Exception:
             pass
-        finally:
-            return
+        return
 
     while True:
         if new_results or nav == 'n':

--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -6,3 +6,4 @@ flask-paginate>=2022.1.8
 flask-reverse-proxy-fix @ https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.3.zip
 Flask-WTF>=1.0.1
 Flask>=2.2.2,<2.3
+werkzeug<2.4

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ server_require = [
     "flask-paginate>=2022.1.8",
     "Flask-WTF>=1.0.1",
     "Flask>=2.2.2,<2.3",
+    "werkzeug<2.4",
 ]
 reverse_proxy = " ".join(
     [


### PR DESCRIPTION
fixes #698:
* adding a limit on `werkzeug` library version (dependency of Flask-API) to fix compatibility problems
* moving `return` statements out of the (unnecessary) `finally:` blocks

also:
* modifying tests to avoid unnecessary network requests (this was causing very long freezes in some tests)