### PR TITLE
[jarun#704] fixed Windows support

### DIFF
--- a/buku
+++ b/buku
@@ -3570,7 +3570,7 @@ def import_html(html_soup: BeautifulSoup, add_parent_folder_as_tag: bool, newtag
         comment_tag = tag.findNextSibling('dd')
 
         if comment_tag:
-            desc = comment_tag.find(text=True, recursive=False)
+            desc = comment_tag.find(string=True, recursive=False)
 
         if add_parent_folder_as_tag:
             # add parent folder as tag
@@ -4721,6 +4721,8 @@ def browse(url):
             # Found a GUI browser, suppress browser output
             browse.suppress_browser_output = True
             break
+    if sys.platform == 'win32':  # GUI apps have no terminal IO on Windows
+        browse.suppress_browser_output = False
 
     if browse.suppress_browser_output:
         _stderr = os.dup(2)
@@ -5276,10 +5278,12 @@ def main():
     """Main."""
     global ID_STR, ID_DB_STR, MUTE_STR, URL_STR, DESC_STR, DESC_WRAP, TAG_STR, TAG_WRAP, PROMPTMSG
     # readline should not be loaded when buku is used as a library
+    import readline
     try:
-        import readline
+        import colorama
+        colorama.just_fix_windows_console()  # noop on non-Windows systems
     except ImportError:
-        import pyreadline3 as readline  # type: ignore
+        pass
 
     title_in = None
     tags_in = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ html5lib>=1.0.1
 setuptools
 urllib3>=1.23,<2
 pyreadline3; sys_platform == 'win32'
+colorama; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires = [
     'html5lib>=1.0.1',
     'urllib3>=1.23,<2',
     'pyreadline3; sys_platform == \'win32\'',
+    'colorama; sys_platform == \'win32\'',
 ]
 
 setup(

--- a/tox.bat
+++ b/tox.bat
@@ -1,0 +1,2 @@
+@if not defined BASEPYTHON set BASEPYTHON=python
+@tox.exe %*

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,10 @@ ignore =
     # E203 whitespace before :
     E203,
 
+[pytest]
+markers =
+  non_tox: not run on tox
+
 [testenv]
 usedevelop = true
 deps = pytest
@@ -56,13 +60,13 @@ commands =
     pytest --cov buku -vv -m "not non_tox" {posargs}
 
 [testenv:pylint]
-basepython = py311
+basepython = {env:BASEPYTHON:py311}
 deps = pylint
 commands =
     pylint . --rc-file tests/.pylintrc --recursive yes --ignore-paths .tox/,build/,venv/
 
 [testenv:flake8]
-basepython = py311
+basepython = {env:BASEPYTHON:py311}
 deps = flake8
 commands =
     python -m flake8


### PR DESCRIPTION
fixes #704:
* fixing error caused by I/O stream manipulation in `browse(url)` on Windows 11

also:
* fixing color support on Windows 7-10
* fixing tests to work on Windows (full `tox` run now succeeds on Windows 7-11… though I'm not actually sure how exactly this works on Windows 7 considering that it's no longer supported by CPython 3.9+ :sweat_smile:)
* fixing unregistered Pytest marker warning when running tests in Tox
* fixing [deprecation warning for `text` argument of BeatifulSoup `.find*()` methods](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#the-string-argument)