### PR TITLE
[jarun#713] fixed HTML encoding detection

### DIFF
--- a/buku
+++ b/buku
@@ -48,6 +48,7 @@ from typing import Any, Dict, List, Optional, Tuple, NamedTuple
 
 import urllib3
 from bs4 import BeautifulSoup
+from bs4.dammit import EncodingDetector
 from urllib3.exceptions import LocationParseError
 from urllib3.util import Retry, make_headers, parse_url
 
@@ -3821,27 +3822,13 @@ def get_data_from_page(resp):
     """
 
     try:
-        soup = BeautifulSoup(resp.data, 'html.parser')
-    except Exception as e:
-        LOGERR('get_data_from_page(): %s', e)
+        charset = EncodingDetector.find_declared_encoding(resp.data, is_html=True)
 
-    try:
-        charset = None
-
-        if soup.meta and soup.meta.get('charset') is not None:
-            charset = soup.meta.get('charset')
-        elif 'content-type' in resp.headers:
+        if not charset and 'content-type' in resp.headers:
             m = email.message.Message()
             m['content-type'] = resp.headers['content-type']
             if m.get_param('charset') is not None:
                 charset = m.get_param('charset')
-
-        if not charset and soup:
-            meta_tag = soup.find('meta', attrs={'http-equiv': 'Content-Type'})
-            if meta_tag:
-                m = email.message.Message()
-                m['content'] = meta_tag.attrs['content']
-                charset = m.get_param('charset', charset)
 
         if charset:
             LOGDBG('charset: %s', charset)

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -945,3 +945,20 @@ def test_convert_tags_to_org_mode_tags(tags, data):
 
     res = convert_tags_to_org_mode_tags(tags)
     assert res == data
+
+
+@pytest.mark.parametrize('charset', ['ISO-8859-1', 'UTF-8'])
+@pytest.mark.parametrize('mode', ['charset', 'content', 'header'])
+def test_get_data_from_page(charset, mode):
+    from urllib3.response import HTTPResponse
+    from buku import get_data_from_page
+    title = 'Répertoire des articles relatifs à l\'Asiminier - Asimina triloba (L.) Dunal (site Les Fruitiers Rares)'
+    headers = (None if mode != 'header' else {'Content-Type': f'text/html; charset={charset}'})
+    meta = {
+        'charset': f'\n<meta charset="{charset}"/>',
+        'content': f'\n<meta http-equiv="content-type" content="text/html; charset={charset}"/>',
+    }.get(mode, '')
+    body = f'<html>\n\n<head>{meta}\n<title>{title}</title>\n</head>\n<body></body>\n\n</html>\n'
+    resp = HTTPResponse(body.encode(charset), headers)
+    parsed_title, desc, keywords = get_data_from_page(resp)
+    assert parsed_title == title


### PR DESCRIPTION
fixes #713:
* replacing the code [that always returns `utf-8`](https://beautiful-soup-4.readthedocs.io/en/latest/#output-encoding) with [BeautifulSoup implementation of charset detection](https://pydocbrowser.github.io/beautifulsoup4/latest/bs4.dammit.EncodingDetector.html#find_declared_encoding)