### PR TITLE
[jarun#711] fixed profile detection for multiple Firefox installs

### DIFF
--- a/buku
+++ b/buku
@@ -67,6 +67,8 @@ DELIM = ','  # Delimiter used to store tags in DB
 SKIP_MIMES = {'.pdf', '.txt'}
 PROMPTMSG = 'buku (? for help): '  # Prompt message string
 
+strip_delim = lambda s, delim=DELIM, sub=' ': str(s).replace(delim, sub)
+
 # Default format specifiers to print records
 ID_STR = '%d. %s [%s]\n'
 ID_DB_STR = '%d. %s'
@@ -2304,7 +2306,7 @@ class BukuDb:
 
         for item in sublist:
             if item['type'] == 'folder':
-                next_folder_name = folder_name + ',' + item['name']
+                next_folder_name = folder_name + DELIM + strip_delim(item['name'])
                 for i in self.traverse_bm_folder(
                         item['children'],
                         unique_tag,
@@ -2404,7 +2406,7 @@ class BukuDb:
                 # add timestamp tag
                 bookmark_tags.append(unique_tag)
 
-            formatted_tags = [DELIM + tag for tag in bookmark_tags]
+            formatted_tags = [DELIM + strip_delim(tag) for tag in bookmark_tags]
             tags = parse_tags(formatted_tags)
 
             # get the title
@@ -2445,7 +2447,7 @@ class BukuDb:
                     add_parent_folder_as_tag):
                 self.add_rec(*item)
 
-    def auto_import_from_browser(self):
+    def auto_import_from_browser(self, firefox_profile=None):
         """Import bookmarks from a browser default database file.
 
         Supports Firefox, Google Chrome, Vivaldi, and Microsoft Edge.
@@ -2456,7 +2458,8 @@ class BukuDb:
             True on success, False on failure.
         """
 
-        ff_bm_db_path = None
+        ff_bm_db_paths = {}
+        firefox_profile = firefox_profile and [firefox_profile]
 
         if sys.platform.startswith(('linux', 'freebsd', 'openbsd')):
             gc_bm_db_path = '~/.config/google-chrome/Default/Bookmarks'
@@ -2464,9 +2467,10 @@ class BukuDb:
             vi_bm_db_path = '~/.config/vivaldi/Default/Bookmarks'
 
             default_ff_folder = os.path.expanduser('~/.mozilla/firefox')
-            profile = get_firefox_profile_name(default_ff_folder)
-            if profile:
-                ff_bm_db_path = '~/.mozilla/firefox/{}/places.sqlite'.format(profile)
+            profiles = firefox_profile or get_firefox_profile_names(default_ff_folder)
+            if profiles:
+                ff_bm_db_paths = {s: '~/.mozilla/firefox/{}/places.sqlite'.format(s)
+                                  for s in profiles}
 
             me_bm_db_path = '~/.config/microsoft-edge/Default/Bookmarks'
         elif sys.platform == 'darwin':
@@ -2475,10 +2479,10 @@ class BukuDb:
             vi_bm_db_path = '~/Library/Application Support/Vivaldi/Default/Bookmarks'
 
             default_ff_folder = os.path.expanduser('~/Library/Application Support/Firefox')
-            profile = get_firefox_profile_name(default_ff_folder)
-            if profile:
-                ff_bm_db_path = ('~/Library/Application Support/Firefox/'
-                                 '{}/places.sqlite'.format(profile))
+            profiles = firefox_profile or get_firefox_profile_names(default_ff_folder)
+            if profiles:
+                ff_bm_db_paths = {s: '~/Library/Application Support/Firefox/{}/places.sqlite'.format(s)
+                                  for s in profiles}
 
             me_bm_db_path = '~/Library/Application Support/Microsoft Edge/Default/Bookmarks'
         elif sys.platform == 'win32':
@@ -2487,9 +2491,10 @@ class BukuDb:
             vi_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Vivaldi/User Data/Default/Bookmarks')
 
             default_ff_folder = os.path.expandvars('%APPDATA%/Mozilla/Firefox/')
-            profile = get_firefox_profile_name(default_ff_folder)
-            if profile:
-                ff_bm_db_path = os.path.join(default_ff_folder, '{}/places.sqlite'.format(profile))
+            profiles = firefox_profile or get_firefox_profile_names(default_ff_folder)
+            if profiles:
+                ff_bm_db_paths = {s: os.path.join(default_ff_folder, '{}/places.sqlite'.format(s))
+                                  for s in profiles}
 
             me_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Microsoft/Edge/User Data/Default/Bookmarks')
         else:
@@ -2511,61 +2516,70 @@ class BukuDb:
         resp = 'y'
 
         try:
-            if self.chatty:
-                resp = input('Import bookmarks from google chrome? (y/n): ')
-            if resp == 'y':
-                bookmarks_database = os.path.expanduser(gc_bm_db_path)
-                if not os.path.exists(bookmarks_database):
-                    raise FileNotFoundError
-                self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+            if os.path.isfile(os.path.expanduser(gc_bm_db_path)):
+                if self.chatty:
+                    resp = input('Import bookmarks from google chrome? (y/n): ')
+                if resp == 'y':
+                    bookmarks_database = os.path.expanduser(gc_bm_db_path)
+                    if not os.path.exists(bookmarks_database):
+                        raise FileNotFoundError
+                    self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
         except Exception as e:
             LOGERR(e)
             print('Could not import bookmarks from google-chrome')
 
         try:
-            if self.chatty:
-                resp = input('Import bookmarks from chromium? (y/n): ')
-            if resp == 'y':
-                bookmarks_database = os.path.expanduser(cb_bm_db_path)
-                if not os.path.exists(bookmarks_database):
-                    raise FileNotFoundError
-                self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+            if os.path.isfile(os.path.expanduser(cb_bm_db_path)):
+                if self.chatty:
+                    resp = input('Import bookmarks from chromium? (y/n): ')
+                if resp == 'y':
+                    bookmarks_database = os.path.expanduser(cb_bm_db_path)
+                    if not os.path.exists(bookmarks_database):
+                        raise FileNotFoundError
+                    self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
         except Exception as e:
             LOGERR(e)
             print('Could not import bookmarks from chromium')
 
         try:
-            if self.chatty:
-                resp = input('Import bookmarks from Vivaldi? (y/n): ')
-            if resp == 'y':
-                bookmarks_database = os.path.expanduser(vi_bm_db_path)
-                if not os.path.exists(bookmarks_database):
-                    raise FileNotFoundError
-                self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+            if os.path.isfile(os.path.expanduser(vi_bm_db_path)):
+                if self.chatty:
+                    resp = input('Import bookmarks from Vivaldi? (y/n): ')
+                if resp == 'y':
+                    bookmarks_database = os.path.expanduser(vi_bm_db_path)
+                    if not os.path.exists(bookmarks_database):
+                        raise FileNotFoundError
+                    self.load_chrome_database(bookmarks_database, newtag, add_parent_folder_as_tag)
         except Exception as e:
             LOGERR(e)
             print('Could not import bookmarks from Vivaldi')
 
         try:
-            if self.chatty:
-                resp = input('Import bookmarks from Firefox? (y/n): ')
-            if resp == 'y':
-                bookmarks_database = os.path.expanduser(ff_bm_db_path)
-                if not os.path.exists(bookmarks_database):
-                    raise FileNotFoundError
-                self.load_firefox_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+            ff_bm_db_paths = {k: s for k, s in ff_bm_db_paths.items() if os.path.isfile(os.path.expanduser(s))}
+            for idx, (name, ff_bm_db_path) in enumerate(ff_bm_db_paths.items(), start=1):
+                if self.chatty:
+                    profile = ('' if len(ff_bm_db_paths) < 2 else
+                               f' profile {name} [{idx}/{len(ff_bm_db_paths)}]')
+                    resp = input(f'Import bookmarks from Firefox{profile}? (y/n): ')
+                if resp == 'y':
+                    bookmarks_database = os.path.expanduser(ff_bm_db_path)
+                    if not os.path.exists(bookmarks_database):
+                        raise FileNotFoundError
+                    self.load_firefox_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+                    break
         except Exception as e:
             LOGERR(e)
             print('Could not import bookmarks from Firefox.')
 
         try:
-            if self.chatty:
-                resp = input('Import bookmarks from microsoft edge? (y/n): ')
-            if resp == 'y':
-                bookmarks_database = os.path.expanduser(me_bm_db_path)
-                if not os.path.exists(bookmarks_database):
-                    raise FileNotFoundError
-                self.load_edge_database(bookmarks_database, newtag, add_parent_folder_as_tag)
+            if os.path.isfile(os.path.expanduser(me_bm_db_path)):
+                if self.chatty:
+                    resp = input('Import bookmarks from microsoft edge? (y/n): ')
+                if resp == 'y':
+                    bookmarks_database = os.path.expanduser(me_bm_db_path)
+                    if not os.path.exists(bookmarks_database):
+                        raise FileNotFoundError
+                    self.load_edge_database(bookmarks_database, newtag, add_parent_folder_as_tag)
         except Exception as e:
             LOGERR(e)
             print('Could not import bookmarks from microsoft-edge')
@@ -3127,16 +3141,17 @@ def convert_bookmark_set(
     return {'data': out, 'count': count}
 
 
-def get_firefox_profile_name(path):
-    """List folder and detect default Firefox profile name.
+def get_firefox_profile_names(path):
+    """List folder and detect default Firefox profile names for all installs.
 
     Returns
     -------
-    profile : str
-        Firefox profile name.
+    profiles : [str]
+        All default Firefox profile names.
     """
     from configparser import ConfigParser, NoOptionError
 
+    profiles = []
     profile_path = os.path.join(path, 'profiles.ini')
     if os.path.exists(profile_path):
         config = ConfigParser()
@@ -3145,34 +3160,33 @@ def get_firefox_profile_name(path):
         install_names = [section for section in config.sections() if section.startswith('Install')]
         for name in install_names:
             try:
-                profile_path = config.get(name, 'default')
-                return profile_path
+                profiles += [config.get(name, 'default')]
             except NoOptionError:
                 pass
+        if profiles:
+            return profiles
 
         profiles_names = [section for section in config.sections() if section.startswith('Profile')]
-        if not profiles_names:
-            return None
         for name in profiles_names:
             try:
                 # If profile is default
                 if config.getboolean(name, 'default'):
-                    profile_path = config.get(name, 'path')
-                    return profile_path
+                    profiles += [config.get(name, 'path')]
+                    continue
             except NoOptionError:
                 pass
             try:
                 # alternative way to detect default profile
                 if config.get(name, 'name').lower() == "default":
-                    profile_path = config.get(name, 'path')
-                    return profile_path
+                    profiles += [config.get(name, 'path')]
             except NoOptionError:
                 pass
 
-        # There is no default profile
-        return None
-    LOGDBG('get_firefox_profile_name(): {} does not exist'.format(path))
-    return None
+        return profiles
+
+    # There are no default profiles
+    LOGDBG('get_firefox_profile_names(): {} does not exist'.format(path))
+    return profiles
 
 
 def walk(root):
@@ -3588,9 +3602,9 @@ def import_html(html_soup: BeautifulSoup, add_parent_folder_as_tag: bool, newtag
                     header = parent.find_previous_sibling('h3')
                     if header:
                         if tag.has_attr('tags'):
-                            tag['tags'] += (DELIM + header.text)
+                            tag['tags'] += (DELIM + strip_delim(header.text))
                         else:
-                            tag['tags'] = header.text
+                            tag['tags'] = strip_delim(header.text)
             else:
                 # could be its folder or not
                 possible_folder = tag.find_previous('h3')
@@ -3600,16 +3614,16 @@ def import_html(html_soup: BeautifulSoup, add_parent_folder_as_tag: bool, newtag
                 if ((possible_folder) and possible_folder.parent in list(tag_list.parents)):
                     # then it's the folder of this bookmark
                     if tag.has_attr('tags'):
-                        tag['tags'] += (DELIM + possible_folder.text)
+                        tag['tags'] += (DELIM + strip_delim(possible_folder.text))
                     else:
-                        tag['tags'] = possible_folder.text
+                        tag['tags'] = strip_delim(possible_folder.text)
 
         # add unique tag if opted
         if newtag:
             if tag.has_attr('tags'):
-                tag['tags'] += (DELIM + newtag)
+                tag['tags'] += (DELIM + strip_delim(newtag))
             else:
-                tag['tags'] = newtag
+                tag['tags'] = strip_delim(newtag)
 
         yield (
             tag['href'], tag.string,
@@ -5411,6 +5425,8 @@ POSITIONAL ARGUMENTS:
         title='POWER TOYS',
         description='''    --ai                 auto-import bookmarks from web browsers
                          Firefox, Chrome, Chromium, Vivaldi, Edge
+                         (Firefox profile can be specified using
+                         environment variable FIREFOX_PROFILE)
     -e, --export file    export bookmarks to Firefox format HTML
                          export XBEL, if file ends with '.xbel'
                          export Markdown, if file ends with '.md'
@@ -5986,7 +6002,7 @@ POSITIONAL ARGUMENTS:
 
     # Import bookmarks from browser
     if args.ai:
-        bdb.auto_import_from_browser()
+        bdb.auto_import_from_browser(firefox_profile=os.environ.get('FIREFOX_PROFILE'))
 
     # Open URL in browser
     if args.open is not None:

--- a/buku.1
+++ b/buku.1
@@ -194,7 +194,7 @@ Decrypt (unlock) the DB file with
 .SH POWER OPTIONS
 .TP
 .BI \--ai
-Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, and Edge browsers.
+Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, and Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE.)
 .TP
 .BI \-e " " \--export " file"
 Export bookmarks to Firefox bookmarks formatted HTML. Works with all search options.

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -709,10 +709,10 @@ def test_import_html_and_add_parent():
 
     from buku import import_html
 
-    html_text = """<DT><H3>1s</H3>
+    html_text = """<DT><H3>1s (blah,blah)</H3>
 <DL><p>
 <DT><A HREF="http://example.com/"></A>"""
-    exp_res = ("http://example.com/", None, ",1s,", None, 0, True, False)
+    exp_res = ("http://example.com/", None, ",1s (blah blah),", None, 0, True, False)
     html_soup = BeautifulSoup(html_text, "html.parser")
     res = list(import_html(html_soup, True, None))
     assert res[0] == exp_res
@@ -737,7 +737,7 @@ def test_import_html_and_add_parent():
                 (
                     "http://example13.com",
                     None,
-                    ",folder11,folder12,folder13,tag3,tag4,",
+                    ",folder11,folder12,folder13 (blah blah),tag3,tag4,",
                     None,
                     0,
                     True,
@@ -760,7 +760,7 @@ def test_import_html_and_add_parent():
                 ("http://example11.com", None, ",folder11,", None, 0, True, False),
                 ("http://example121.com", None, ",folder121,", None, 0, True, False),
                 ("http://example12.com", None, None, None, 0, True, False),
-                ("http://example13.com", None, ",folder13,tag3,tag4,", None, 0, True, False),
+                ("http://example13.com", None, ",folder13 (blah blah),tag3,tag4,", None, 0, True, False),
             ],
         ),
     ],
@@ -788,7 +788,7 @@ def test_import_html_and_add_all_parent(add_all_parent, exp_res):
             <DT><A HREF="http://example121.com"></A></DT>
         </DL><p></DT>
         <DT><A HREF="http://example12.com"></A></DT>
-        <DT><H3>Folder13</H3><DL><p>
+        <DT><H3>Folder13 (blah,blah)</H3><DL><p>
             <DT><A HREF="http://example13.com" TAGS="tag3,tag4"></A></DT>
         </DL><p></DT>
     </DL><p></DT>

--- a/tests/test_bukuDb/25491522_res.yaml
+++ b/tests/test_bukuDb/25491522_res.yaml
@@ -2,14 +2,14 @@
   true, false]
 : {}
 ? !!python/tuple ['http://wiki.ubuntu.com/', Ubuntu Wiki (community-edited website),
-  ',bookmarks bar,imported from firefox,ubuntu and free software links,', null, 0,
+  ',bookmarks bar,imported from firefox (2011-09-02  06:03:50),ubuntu and free software links,', null, 0,
   true, false]
 : {}
 ? !!python/tuple ['http://www.debian.org/', Debian (Ubuntu is based on Debian), ',bookmarks
-    bar,imported from firefox,ubuntu and free software links,', null, 0, true, false]
+    bar,imported from firefox (2011-09-02  06:03:50),ubuntu and free software links,', null, 0, true, false]
 : {}
 ? !!python/tuple ['http://www.ubuntu.com/', Ubuntu, ',bookmarks bar,imported from
-    firefox,ubuntu and free software links,', null, 0, true, false]
+    firefox (2011-09-02  06:03:50),ubuntu and free software links,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://addons.mozilla.org/fr/firefox/addon/adblock-plus/', Adblock
     Plus, ',bookmarks bar,f+,', null, 0, true, false]
@@ -21,25 +21,25 @@
     Tools, ',bookmarks bar,f+,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://answers.launchpad.net/ubuntu/+addquestion', Make a Support
-    Request to the Ubuntu Community, ',bookmarks bar,imported from firefox,ubuntu
+    Request to the Ubuntu Community, ',bookmarks bar,imported from firefox (2011-09-02  06:03:50),ubuntu
     and free software links,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://one.ubuntu.com/', Ubuntu One - The personal cloud that
-    brings your digital life together, ',bookmarks bar,imported from firefox,ubuntu
+    brings your digital life together, ',bookmarks bar,imported from firefox (2011-09-02  06:03:50),ubuntu
     and free software links,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://www.google.com/', Google, ',other bookmarks,', null, 0,
   true, false]
 : {}
 ? !!python/tuple ['https://www.mozilla.org/en-US/about/', About Us, ',bookmarks bar,imported
-    from firefox,mozilla firefox,', null, 0, true, false]
+    from firefox (2011-09-02  06:03:50),mozilla firefox,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://www.mozilla.org/en-US/contribute/', Get Involved, ',bookmarks
-    bar,imported from firefox,mozilla firefox,', null, 0, true, false]
+    bar,imported from firefox (2011-09-02  06:03:50),mozilla firefox,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://www.mozilla.org/en-US/firefox/customize/', Customize Firefox,
-  ',bookmarks bar,imported from firefox,mozilla firefox,', null, 0, true, false]
+  ',bookmarks bar,imported from firefox (2011-09-02  06:03:50),mozilla firefox,', null, 0, true, false]
 : {}
 ? !!python/tuple ['https://www.mozilla.org/en-US/firefox/help/', Help and Tutorials,
-  ',bookmarks bar,imported from firefox,mozilla firefox,', null, 0, true, false]
+  ',bookmarks bar,imported from firefox (2011-09-02  06:03:50),mozilla firefox,', null, 0, true, false]
 : {}

--- a/tests/test_bukuDb/Bookmarks
+++ b/tests/test_bukuDb/Bookmarks
@@ -287,7 +287,7 @@
             "date_added": "13149362306507580",
             "date_modified": "13149362306507581",
             "id": "41",
-            "name": "Imported From Firefox",
+            "name": "Imported From Firefox (2011-09-02, 06:03:50)",
             "type": "folder"
          } ],
          "date_added": "13149362288728239",


### PR DESCRIPTION
fixes #711:
* changing Firefox profile detection from single to multiple when multiple installs are found (asking which one to pick until one is chosen)
* adding support for environment variable (`FIREFOX_PROFILE`) in CLI & parameter (`firefox_profile`) in API

also:
* skipping nonexistent bookmark files
* stripping commas (tag delimiter) from imported tags (particularly parent folder ones)