### PR TITLE
ci: add py3.12 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ lint-template: &lint-template
 jobs:
   lint:
     docker:
-      - image: python:3.11-slim
+      - image: python:3.12-slim
     <<: *lint-template
 
   py38:
@@ -64,6 +64,11 @@ jobs:
   py311:
     docker:
       - image: python:3.11-slim
+    <<: *test-template
+
+  py312:
+    docker:
+      - image: python:3.12-slim
     <<: *test-template
 
 #  package-and-publish:
@@ -161,4 +166,3 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ workflows:
       - py39
       - py310
       - py311
+      - py312
 
   nightly:
     triggers:

--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -228,7 +228,7 @@ class ApiBookmarkSearchView(MethodView):
 
     def get(self):
         arg_obj = request.args
-        keywords = arg_obj.getlist('keywords')
+        keywords = arg_obj.getlist('keywords')  # pylint: disable=E1101
         all_keywords = arg_obj.get('all_keywords')
         deep = arg_obj.get('deep')
         regex = arg_obj.get('regex')

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -68,7 +68,7 @@ def last_page(self):
                                 view_args.search, view_args.filters, page_size=page_size)
 
     args = request.args.copy()
-    args.setlist('page', [max(0, (count - 1) // page_size)])
+    args.setlist('page', [max(0, (count - 1) // page_size)])  # pylint: disable=E1101
     return redirect(url_for('.index_view', **args))
 
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
         'Topic :: Utilities'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,pylint,flake8
+envlist = py38,py39,py310,py311,py312,pylint,flake8
 
 [flake8]
 max-line-length = 139
@@ -61,26 +61,31 @@ extras = tests
 commands =
     pytest --cov buku -vv -m "not non_tox" {posargs}
 
+[testenv:py312]
+extras = tests
+commands =
+    pytest --cov buku -vv -m "not non_tox" {posargs}
+
 [testenv:quick]
-basepython = {env:BASEPYTHON:py311}
+basepython = {env:BASEPYTHON:py312}
 extras = tests
 commands =
     pytest --cov buku -vv -m "not non_tox and not slow" {posargs}
 
 [testenv:nogui]
-basepython = {env:BASEPYTHON:py311}
+basepython = {env:BASEPYTHON:py312}
 extras = tests
 commands =
     pytest --cov buku -vv -m "not non_tox and not gui" {posargs}
 
 [testenv:pylint]
-basepython = {env:BASEPYTHON:py311}
+basepython = {env:BASEPYTHON:py312}
 deps = pylint
 commands =
     pylint . --rc-file tests/.pylintrc --recursive yes --ignore-paths .tox/,build/,venv/
 
 [testenv:flake8]
-basepython = {env:BASEPYTHON:py311}
+basepython = {env:BASEPYTHON:py312}
 deps = flake8
 commands =
     python -m flake8


### PR DESCRIPTION
I have migrated the [brew build into py3.12](https://github.com/Homebrew/homebrew-core/pull/150977), and it works out fine, thus adding the support in here as well.