### PR TITLE
fix pylint warnings by fixing a test

### DIFF
--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -228,7 +228,7 @@ class ApiBookmarkSearchView(MethodView):
 
     def get(self):
         arg_obj = request.args
-        keywords = arg_obj.getlist('keywords')  # pylint: disable=E1101
+        keywords = arg_obj.getlist('keywords')
         all_keywords = arg_obj.get('all_keywords')
         deep = arg_obj.get('deep')
         regex = arg_obj.get('regex')

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -68,7 +68,7 @@ def last_page(self):
                                 view_args.search, view_args.filters, page_size=page_size)
 
     args = request.args.copy()
-    args.setlist('page', [max(0, (count - 1) // page_size)])  # pylint: disable=E1101
+    args.setlist('page', [max(0, (count - 1) // page_size)])
     return redirect(url_for('.index_view', **args))
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,7 @@ from argparse import Namespace
 import pytest
 from flask import request
 from lxml import etree
+from werkzeug.datastructures import MultiDict
 
 from buku import BukuDb
 from bukuserver import server
@@ -98,7 +99,7 @@ def test_tag_model_view_get_list(tmv_instance, sort_field, sort_desc, filters, e
 ])
 def test_bmv_create_form(bmv_instance, url, backlink, app):
     with app.test_request_context():
-        request.args = {'link': url, 'url': backlink} if backlink else {'link': url}
+        request.args = MultiDict({'link': url, 'url': backlink} if backlink else {'link': url})
         form = bmv_instance.create_form()
         assert form.url.data == url
 

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,9 @@ commands =
 
 [testenv:pylint]
 basepython = {env:BASEPYTHON:py312}
-deps = pylint
+deps =
+    pylint
+    .[tests]
 commands =
     pylint . --rc-file tests/.pylintrc --recursive yes --ignore-paths .tox/,build/,venv/
 


### PR DESCRIPTION
I couldn't manage to reproduce the warnings locally… ~~I wonder what's causing the difference :thinking:~~ Turns out pylint misses some checks when it doesn't have access to sources of imported modules. (…Also it only works with Python **3.12** for some reason.)