### PR TITLE
[jarun#753] temporarily block flake-admin-v2 & actualize install instructions

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -20,22 +20,19 @@ So be sure to have `python3`, `python3-pip` , `python3-dev`, `libffi-dev` packag
 #### Dependencies
 
 ```
-$ python3 -m pip install --user --upgrade pip
-$ python3 -m pip install --user virtualenv
-$ python3 -m virtualenv env
-$ source env/bin/activate
+$ # venv activation (for development)
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install --upgrade pip
 ```
 
 #### From PyPi
 
 ```sh
-$ # basic server
+$ # regular/venv install
 $ pip3 install "buku[server]"
-$ # server with reverse proxy
-$ pip3 install "buku[server,reverse_proxy]"
-$ # pipx install bukuserver with reverse proxy
+$ # pipx install
 $ pipx install "buku[server]"
-$ pipx inject buku https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/archive/refs/tags/v0.2.2rc1.zip
 ```
 
 #### From source
@@ -43,10 +40,8 @@ $ pipx inject buku https://github.com/rachmadaniHaryono/flask-reverse-proxy-fix/
 ```sh
 $ git clone https://github.com/jarun/buku
 $ cd buku
-$ # basic server
+$ # regular/venv install
 $ pip3 install ".[server]"
-$ # server with reverse_proxy
-$ pip3 install ".[server,reverse_proxy]"
 ```
 
 #### Using Docker

--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.2.2
-Flask-Admin>=1.6.1
+Flask-Admin>=1.6.1,<2
 Flask-API>=3.0.post1
 Flask-Bootstrap>=3.3.7.1
 flask-paginate>=2022.1.8

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -76,8 +76,8 @@ def init_locale(app):
         except ImportError:
             from flask_babel import Babel
             Babel().init_app(app, locale_selector=lambda: app.config['BUKUSERVER_LOCALE'])
-    except Exception:
-        app.logger.warning('failed to init locale')
+    except Exception as e:
+        app.logger.warning(f'failed to init locale ({e})')
 
 
 def create_app(db_file=None):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ tests_require = [
 
 server_require = [
     "arrow>=1.2.2",
-    "Flask-Admin>=1.6.1",
+    "Flask-Admin>=1.6.1,<2",
     "Flask-API>=3.0.post1",
     "Flask-Bootstrap>=3.3.7.1",
     "flask-paginate>=2022.1.8",


### PR DESCRIPTION
* blocking `flake-admin` v2 until able to migrate properly when it's released (see #753)
* fixing outdated install instructions in bukuserver readme (e.g. `[reverse_proxy]` flag – see #722)