### PR TITLE
bukuserver readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 `buku` is a powerful bookmark manager and a personal textual mini-web.
 
-For those who prefer the GUI, [bukuserver](https://github.com/jarun/buku/tree/master/bukuserver#readme) exposes a browsable front-end on a local web host server.
+For those who prefer the GUI, `bukuserver` exposes a browsable front-end on a local web host server. See [bukuserver page](https://github.com/jarun/buku/tree/master/bukuserver#readme) for config and screenshots.
 
 When I started writing it, I couldn't find a flexible command-line solution with a private, portable, merge-able database along with seamless GUI integration. Hence, `buku`.
 

--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -115,7 +115,7 @@ The following are os env config variables available for bukuserver.
 | URL_RENDER_MODE | url render mode | `full` or `netloc` [default: `full`] |
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
 | READONLY | read-only mode | boolean [default: `false`] |
-| DISABLE_FAVICON | disable bookmark [favicons](https://wikipedia.org/wiki/Favicon) | boolean [default: `true`] |
+| DISABLE_FAVICON | disable bookmark [favicons](https://wikipedia.org/wiki/Favicon) | boolean [default: `true`] ([here's why](#why-favicons-are-disabled-by-default))|
 | OPEN_IN_NEW_TAB | url link open in new tab | boolean [default: `false`] |
 | REVERSE_PROXY_PATH | reverse proxy path | string |
 | THEME | [GUI theme](https://bootswatch.com/3) | string [default: `default`] (`slate` is a good pick for dark mode) |
@@ -146,6 +146,22 @@ Note: the value for BUKUSERVER_REVERSE_PROXY_PATH
 is recommended to include preceding slash and not have trailing slash
 (i.e. use `/foo` not `/foo/`)
 
+#### Why favicons are disabled by default
+
+At Bukuserver, we have [disabled favicon as a default setting](#configuration) in order to prevent any non-user triggered network activity.
+
+Our favicon is generated with the assistance of Google.
+
+It is important to be aware that favicon has the potential to be used for browser fingerprinting,
+a technique used to identify and track a person's web browsing habits.
+
+- [Github repo example supercookie](https://github.com/jonasstrehle/supercookie)
+- [Paper by Scientists at University of Illinois, Chicago](https://www.cs.uic.edu/~polakis/papers/solomos-ndss21.pdf)
+- [Article published in 2021 at Heise Online](https://heise.de/-5027814)
+  ([English translation](https://www-heise-de.translate.goog/news/Browser-Fingerprinting-Favicons-als-Super-Cookies-5027814.html?_x_tr_sl=de&_x_tr_tl=en&_x_tr_hl=en))
+
+It is important to note that favicon can potentially be exploited in this way.
+
 ### Screenshots
 
 <p><br></p>
@@ -166,11 +182,21 @@ is recommended to include preceding slash and not have trailing slash
 
 <p><br><br></p>
 <p align="center">
-  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-page.png?raw=true">
-    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-page.png" alt="bookmark page" width="650"/>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.8/bukuserver/bookmark-page-with-favicon-enabled.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.8/bukuserver/bookmark-page-with-favicon-enabled.png"
+          alt="bookmark page with favicon enabled" width="650"/>
   </a>
 </p>
-<p align="center"><i>bookmark page</i></a></p>
+<p align="center"><i>bookmark page <a href="#configuration">with favicon enabled</a></i></p>
+
+<p><br><br></p>
+<p align="center">
+  <a href="https://github.com/Buku-dev/docs/blob/v4.8a/bukuserver/bookmark-page-with-slate-theme-and-favicon-enabled.png">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.8a/bukuserver/bookmark-page-with-slate-theme-and-favicon-enabled.png"
+         alt="bookmark page with 'slate' theme and favicon enabled" width="650"/>
+  </a>
+</p>
+<p align="center"><i>bookmark page with 'slate' theme and favicon enabled</i></a></p>
 
 <p><br><br></p>
 <p align="center">

--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -150,42 +150,56 @@ is recommended to include preceding slash and not have trailing slash
 
 <p><br></p>
 <p align="center">
-<a href="https://i.imgur.com/LozEqsT.png"><img src="https://i.imgur.com/LozEqsT.png" alt="home page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/home-page.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/home-page.png" alt="home page" width="650"/>
+  </a>
 </p>
 <p align="center"><i>home page</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/DJUzs1d.png"><img src="https://i.imgur.com/DJUzs1d.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-stats.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-stats.png" alt="bookmark stats" width="650"/>
+  </a>
 </p>
 <p align="center"><i>bookmark stats</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/1eMruZD.png"><img src="https://i.imgur.com/1eMruZD.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-page.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/bookmark-page.png" alt="bookmark page" width="650"/>
+  </a>
 </p>
 <p align="center"><i>bookmark page</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/W4VUKQV.png"><img src="https://i.imgur.com/W4VUKQV.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/create-bookmark.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/create-bookmark.png" alt="create bookmark" width="650"/>
+  </a>
 </p>
 <p align="center"><i>create bookmark</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/213y0Ft.png"><img src="https://i.imgur.com/213y0Ft.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/edit-bookmark.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/edit-bookmark.png" alt="edit bookmark" width="650"/>
+  </a>
 </p>
 <p align="center"><i>edit bookmark</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/MQM07VZ.png"><img src="https://i.imgur.com/MQM07VZ.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/view-bookmark-details.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/view-bookmark-details.png" alt="view bookmark details" width="650"/>
+  </a>
 </p>
 <p align="center"><i>view bookmark details</i></a></p>
 
 <p><br><br></p>
 <p align="center">
-<a href="https://i.imgur.com/0bYgpER.png"><img src="https://i.imgur.com/0bYgpER.png" alt="index page" width="650"/></a>
+  <a href="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/tag-page.png?raw=true">
+    <img src="https://github.com/Buku-dev/docs/blob/v4.7/bukuserver/tag-page.png" alt="tag page" width="650"/>
+  </a>
 </p>
 <p align="center"><i>tag page</i></a></p>

--- a/docs/source/tutorial_for_developer.md
+++ b/docs/source/tutorial_for_developer.md
@@ -1,0 +1,41 @@
+# Tutorial for Developer
+
+## get buku database
+
+```ptyhon
+>>> import buku
+>>> bdb = buku.BukuDb()
+```
+
+## simplest way to add url to buku
+
+```python
+>>> rec_id = bdb.add_rec('http://example.com')
+>>> rec_id
+40296
+```
+
+## get record id from url
+
+```python
+>>> url = 'https://example.com'
+>>> rec_id = bdb.add_rec(url)
+... if rec_id == -1:
+...     rec_id = bdb.get_rec_id(url)
+>>> rec_id
+40296
+```
+
+## get url data from record id
+
+```python
+>>> rec = bdb.get_rec_by_id(40296)
+>>> rec
+(40296, 'http://example.com', 'Example Domain', ',', '', 0)
+```
+
+## get tag list
+
+```python
+rec[3].split(buku.delim)
+```


### PR DESCRIPTION
Since bukuserver screenshots will become outdated after migrating to Bootstrap v4 (at least both `default` and `slate` themes are visibly different from their v3 counterparts), I decided to copy the changes from #657 (on which there had been no activity _for a year and a half_ by now, incidentally) and do the requested changes myself.

I addressed the versioning issue (as well as some accessibility issues caused by relying on Imgur) via creating [a repo for storing documentation assets](https://github.com/Buku-dev/buku-docs); all images (and image links) are now versioned via tags. I split the changes in 2 commits: first to make the switch (using current repo screenshots), and the second contains changes from the original pull-request (including the new screenshot… or rather its cropped version which I added later).

Feel free to offer further suggestions for the pull-request (like removing/modifying the "Tutorial for developer" file which seems incomplete and possibly doesn't really belong in this changeset). Note that the docs repo includes [a screenshot which is present in the Imgur gallery but was not added to the readme](https://github.com/Buku-dev/buku-docs/blob/v4.8a/bukuserver/bookmark-page-with-slate-theme-and-favicon-disabled.png).