### PR TITLE
improved markdown & orgmode parsing

### DIFF
--- a/buku
+++ b/buku
@@ -3560,41 +3560,22 @@ def import_md(filepath: str, newtag: Optional[str]):
     tuple
         Parsed result.
     """
+    # Supported Markdown format: `[title](url) <!-- TAGS: tags -->` (or `<url> <!-- TAGS: tags -->`)
+    _named_link, _raw_link = r'\[(?P<title>.*)\]\((?P<url>.+)\)', r'\<(?P<url_raw>[^!>][^>]*)\>'
+    pattern = re.compile(r'(%s|%s)(\s+<!-- TAGS: (?P<tags>.*) -->)?' % (_named_link, _raw_link))
     with open(filepath, mode='r', encoding='utf-8') as infp:
         for line in infp:
-            # Supported Markdown format: [title](url)
-            # Find position of title end, url start delimiter combo
-            index = line.find('](')
-            if index != -1:
-                # Find title start delimiter
-                title_start_delim = line[:index].find('[')
-                # Reverse find the url end delimiter
-                url_end_delim = line[index + 2:].rfind(')')
+            if match := pattern.search(line):
+                title = match.group('title') or ''
+                url = match.group('url') or match.group('url_raw')
 
-                if title_start_delim != -1 and url_end_delim > 0:
-                    # Parse title
-                    title = line[title_start_delim + 1:index]
-                    # Parse url
-                    url = line[index + 2:index + 2 + url_end_delim]
-                    if is_nongeneric_url(url):
-                        continue
+                if is_nongeneric_url(url):
+                    continue
 
-                    # Find tag start delimiter
-                    tag_start_delim = line.find('<!-- TAGS: ')
-                    # Reverse find tag end delimiter
-                    tag_end_delim = line.rfind(' -->')
+                tags = DELIM.join(s for s in [newtag, match.group('tags')] if s)
+                tags = parse_tags([tags])
 
-                    if tag_start_delim != -1 and tag_end_delim > 0:
-                        if newtag is not None:
-                            tags = newtag + ',' + line[tag_start_delim + 11:tag_end_delim]
-                        else:
-                            tags = line[tag_start_delim + 11:tag_end_delim]
-                    else:
-                        tags = newtag
-
-                    parse_tags([tags])
-
-                    yield (url, title, delim_wrap(tags), None, 0, True, False)
+                yield (url, title, delim_wrap(tags), None, 0, True, False)
 
 def import_rss(filepath: str, newtag: Optional[str]):
     """Parse bookmark RSS file.
@@ -3656,7 +3637,7 @@ def import_org(filepath: str, newtag: Optional[str]):
         list
             List of tags
         """
-        tag_list_raw = [i for i in re.split(r'(?<!\:)\:', tag_string) if i]
+        tag_list_raw = [s for s in re.split(r'(?<!\:)\:', tag_string) if s]
         tag_list_cleaned = []
         for i, tag in enumerate(tag_list_raw):
             if tag.startswith(":"):
@@ -3670,34 +3651,24 @@ def import_org(filepath: str, newtag: Optional[str]):
                 tag_list_cleaned.append(tag.strip())
         return tag_list_cleaned
 
+    # Supported OrgMode format: `[[url][title]] :tags:` (or `[[url]] :tags:`)
+    _url, _maybe_title = r'(?P<url>((?!\]\[).)+?)', r'(\]\[(?P<title>.+))?'
+    pattern = re.compile(r'\[\[%s%s\]\](?P<tags>\s+:.*:)?' % (_url, _maybe_title))
     with open(filepath, mode='r', encoding='utf-8') as infp:
-        # Supported Markdown format: * [[url][title]] :tags:
-        # Find position of url end, title start delimiter combo
         for line in infp:
-            index = line.find('][')
-            if index != -1:
-                # Find url start delimiter
-                url_start_delim = line[:index].find('[[')
-                # Reverse find title end delimiter
-                title_end_delim = line[index + 2:].rfind(']]')
+            if match := pattern.search(line):
+                title = match.group('title') or ''
+                url = match.group('url')
 
-                if url_start_delim != -1 and title_end_delim > 0:
-                    # Parse title
-                    title = line[index + 2: index + 2 + title_end_delim]
-                    # Parse url
-                    url = line[url_start_delim + 2:index]
-                    # Parse Tags
-                    tags = list(collections.OrderedDict.fromkeys(get_org_tags(line[(index + 4 + title_end_delim):])))
-                    tags_string = DELIM.join(tags)
+                if is_nongeneric_url(url):
+                    continue
 
-                    if is_nongeneric_url(url):
-                        continue
+                tags = list(dict.fromkeys(get_org_tags(match.group('tags') or '')))
+                tags_string = DELIM.join(tags)
+                if newtag and newtag.lower() not in tags:
+                    tags_string = (newtag + DELIM) + tags_string
 
-                    if newtag:
-                        if newtag.lower() not in tags:
-                            tags_string = (newtag + DELIM) + tags_string
-
-                    yield (url, title, delim_wrap(tags_string), None, 0, True, False)
+                yield (url, title, delim_wrap(tags_string), None, 0, True, False)
 
 def import_firefox_json(json, add_bookmark_folder_as_tag=False, unique_tag=None):
     """Open Firefox JSON export file and import data.


### PR DESCRIPTION
When trying to import [a generated DB file](https://gist.github.com/LeXofLeviafan/47def9c55ee9107680e7790c86e07453), I've noticed some irregularities. I went around the issue by converting the file to [Markdown format](https://gist.github.com/LeXofLeviafan/fbc4c88e3db22c3c080c1ea81d0ae16e), but I still ended up making a few improvements to the parsing code; namely:
* reimplemented Markdown/OrgMode parsing via regex
* added support for "raw links" (`<url>`/`[[url]]`)
* added tests for all valid _and invalid_ link formats (based on which formats Pandoc can handle, and treating blank links as "always invalid")

<details><summary><h2>Markdown import</h2></summary>

```markdown
* [Bookmark title](http://example.com/1) <!-- TAGS: tag 1, tag 2, tag 3 -->
* [Bookmark title](javascript:void(2))   <!-- TAGS: tag 1, tag 2, tag 3 -->
* [Bookmark title]()                     <!-- TAGS: tag 1, tag 2, tag 3 -->
* [](http://example.com/4)               <!-- TAGS: tag 1, tag 2, tag 3 -->
* [](javascript:void(5))                 <!-- TAGS: tag 1, tag 2, tag 3 -->
* []()                                   <!-- TAGS: tag 1, tag 2, tag 3 -->
* <http://example.com/7>                 <!-- TAGS: tag 1, tag 2, tag 3 -->
* <javascript:void(8)>                   <!-- TAGS: tag 1, tag 2, tag 3 -->
* <>                                     <!-- TAGS: tag 1, tag 2, tag 3 -->
* [Bookmark title](http://example.com/10)
* [Bookmark title](javascript:void(11))
* [Bookmark title]()
* [](http://example.com/13)
* [](javascript:void(14))
* []()
* <http://example.com/16>
* <javascript:void(17)>
* <>
```
![imported](https://github.com/user-attachments/assets/4d5c46b0-3b1f-45a6-a92a-1244f7e9bf93)
</details>
<details><summary><h2>OrgMode import</h2></summary>

```orgmode
- [[http://example.com/1][Bookmark title]] :tag 1:tag 2:tag 3:
- [[javascript:void(2)][Bookmark title]]   :tag 1:tag 2:tag 3:
- [[][Bookmark title]]                     :tag 1:tag 2:tag 3:
- [[http://example.com/4][]]               :tag 1:tag 2:tag 3:
- [[javascript:void(5)][]]                 :tag 1:tag 2:tag 3:
- [[][]]                                   :tag 1:tag 2:tag 3:
- [[http://example.com/7]]                 :tag 1:tag 2:tag 3:
- [[javascript:void(8)]]                   :tag 1:tag 2:tag 3:
- [[]]                                     :tag 1:tag 2:tag 3:
- [[http://example.com/10][Bookmark title]]
- [[javascript:void(11)][Bookmark title]]
- [[][Bookmark title]]
- [[http://example.com/13][]]
- [[javascript:void(14)][]]
- [[][]]
- [[http://example.com/16]]
- [[javascript:void(17)]]
- [[]]
```
(Unlike in Markdown, empty titles – `[[url][]]` – are explicitly invalid in OrgMode)
![imported](https://github.com/user-attachments/assets/b008e4a4-e808-4bc5-a396-fdebf79bf91d)
</details>
