### PR TITLE
ensuring that popup links always open externally

### DIFF
--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -3,9 +3,9 @@
 
 {% block tail %}
   {{ super() }}
+  {{ buku.limit_navigation_if_popup() }}
   {{ buku.script('bookmark.js') }}
   {{ buku.fetch_checkbox() }}
   {{ buku.focus() }}
   {{ buku.link_saved() }}
-  {{ buku.limit_navigation_if_popup() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -3,8 +3,8 @@
 
 {% block tail %}
   {{ super() }}
+  {{ buku.limit_navigation_if_popup() }}
   {{ buku.details_formatting() }}
   <script>$('#fa_filter, .table.searchable a').attr('tabindex', 1)</script>
   {{ buku.link_saved() }}
-  {{ buku.limit_navigation_if_popup() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_edit.html
+++ b/bukuserver/templates/bukuserver/bookmark_edit.html
@@ -21,9 +21,9 @@
 
 {% block tail %}
   {{ super() }}
+  {{ buku.limit_navigation_if_popup() }}
   {{ buku.script('bookmark.js') }}
   {{ buku.focus() }}
   {{ buku.link_saved() }}
-  {{ buku.limit_navigation_if_popup() }}
   <script>$('.submit-row').append($('.delete-form'))</script>
 {% endblock %}

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -42,11 +42,12 @@
 
 {% macro details_formatting(prefix='') %}
   <script>{
-    const TARGET = {{ (' target="_blank"' if config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False) else '') | tojson }};
     $(`{{prefix}} td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'));
-    {% if session.pop('netloc', None) %}
+    {%- if session.pop('netloc', None) %}
+    const NEW_TAB = {{ config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False)|tojson }};
+    const TARGET = (!NEW_TAB && !document.body.matches('.popup') ? '' : ' target="_blank"');
     $(`{{prefix}} td:contains({{ _gettext('Url') | tojson }}) + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${TARGET}>${s}</a>`);
-    {% endif %}
+    {%- endif %}
   }</script>
 {% endmacro %}
 


### PR DESCRIPTION
Come to think of it, the bookmarklet popup window is not a good place to open other pages in; so we should override `BUKUSERVER_OPEN_IN_NEW_TAB` inside popups.