### PR TITLE
improving bookmark details view

### DIFF
--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -4,4 +4,5 @@ Flask-API>=3.0.post1
 flask-paginate>=2022.1.8
 Flask-WTF>=1.0.1
 Flask>=2.2.2,<2.3
+Jinja2>=3
 werkzeug<2.4

--- a/bukuserver/static/bukuserver/css/bookmark.css
+++ b/bukuserver/static/bukuserver/css/bookmark.css
@@ -15,10 +15,15 @@ table tr td:not(:first-child) {
 }
 
 .tag-list {
-    font-size: larger;
     display: flex;
     gap: 1px;
     flex-wrap: wrap;
+}
+.tag-list, .link .netloc {
+    font-size: larger;
+}
+.tag-list a, .link .netloc, .select2-search-choice > *, .select2-result-label {
+    white-space: pre;
 }
 
 .description {

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -4,7 +4,7 @@
 {% block tail %}
   {{ super() }}
   {{ buku.limit_navigation_if_popup() }}
-  {{ buku.details_formatting() }}
+  {{ buku.details_formatting('.table.searchable') }}
   <script>$('#fa_filter, .table.searchable a').attr('tabindex', 1)</script>
   {{ buku.link_saved() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -41,14 +41,9 @@
 {% endmacro %}
 
 {% macro details_formatting(prefix='') %}
-  <script>{
-    $(`{{prefix}} td:nth-child(2)`).html((_, s) => s.trim().replaceAll('\n', '<br/>'));
-    {%- if session.pop('netloc', None) %}
-    const NEW_TAB = {{ config.get('BUKUSERVER_OPEN_IN_NEW_TAB', False)|tojson }};
-    const TARGET = (!NEW_TAB && !document.body.matches('.popup') ? '' : ' target="_blank"');
-    $(`{{prefix}} td:contains({{ _gettext('Url') | tojson }}) + td`).html((_, s) => `<a href="${s.replaceAll('"', '&quot;')}"${TARGET}>${s}</a>`);
-    {%- endif %}
-  }</script>
+  <script>
+    $(`body.popup {{prefix}} a`).attr('target', '_blank');
+  </script>
 {% endmacro %}
 
 {% macro link_saved() %}

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ server_require = [
     "flask-paginate>=2022.1.8",
     "Flask-WTF>=1.0.1",
     "Flask>=2.2.2,<2.3",
+    "Jinja2>=3",
     "werkzeug<2.4",
 ]
 install_requires = [


### PR DESCRIPTION
After some more fiddling I decided to move the URL enhancement of the details view to the backend, along with enhancing other fields as well (similar to the bookmarks list view).
![details popup](https://github.com/user-attachments/assets/95194edc-4118-466a-8558-4319aeb87680)
* tags are rendered as badges (functioning as clickable filters)
  + edge cases are handled correctly
    ![unusual tags](https://github.com/user-attachments/assets/033e308d-d6c2-483b-9409-1ba6ad451260)
  + also applies to the input form
    ![input tags](https://github.com/user-attachments/assets/c8d365ad-529e-4bec-8f65-78547ed31026)
    ![autocomplete](https://github.com/user-attachments/assets/26514822-e675-4cb9-8f02-86de24c55e5a)
* favicon is displayed (if enabled) before the URL; it doubles as a netloc filter
  + when favicons are disabled, displaying a regular netloc badge instead
    ![netloc badge](https://github.com/user-attachments/assets/25ee4372-47de-40eb-a9fd-5a89d9f97988)
* description is rendered with preserved spacing
  ![description](https://github.com/user-attachments/assets/638cf9bf-3b05-468f-9cc8-5c341d7be4ac)

…And yes, within a popup all these links will get opened externally.