### PR TITLE
support overriding fetched tags when adding a bookmark

### DIFF
--- a/buku
+++ b/buku
@@ -73,8 +73,11 @@ PROMPTMSG = 'buku (? for help): '  # Prompt message string
 
 strip_delim = lambda s, delim=DELIM, sub=' ': str(s).replace(delim, sub)
 taglist = lambda ss: sorted(s.lower() for s in set(ss) if s)
-taglist_str = lambda s: delim_wrap(DELIM.join(taglist(s.split(DELIM))))
 like_escape = lambda s, c='`': s.replace(c, c+c).replace('_', c+'_').replace('%', c+'%')
+
+def taglist_str(tag_str, convert=None):
+    tags = taglist(tag_str.split(DELIM))
+    return delim_wrap(DELIM.join(tags if not convert else taglist(convert(tags))))
 
 # Default format specifiers to print records
 ID_STR = '%d. %s [%s]\n'
@@ -725,7 +728,9 @@ class BukuDb:
             url_redirect: bool = False,
             tag_redirect: bool | str = False,
             tag_error: bool | str = False,
-            del_error: Optional[Set[int] | range] = None) -> int:  # Optional[IntSet]
+            del_error: Optional[Set[int] | range] = None,
+            tags_fetch: bool = True,
+            tags_except: Optional[str] = None) -> int:  # Optional[IntSet]
         """Add a new bookmark.
 
         Parameters
@@ -735,8 +740,11 @@ class BukuDb:
         title_in : str, optional
             Title to add manually. Default is None.
         tags_in : str, optional
-            Comma-separated tags to add manually.
-            Must start and end with comma. Default is None.
+            Comma-separated tags to add manually, instead of fetching them. Default is None.
+        tags_except : str, optional
+            These are removed from the resulting tags list. Default is None.
+        tags_fetch : bool
+            True if tags parsed from the fetched page should be included. Default is True.
         desc : str, optional
             Description of the bookmark. Default is None.
         immutable : bool
@@ -794,7 +802,11 @@ class BukuDb:
         title = (title_in if title_in is not None else result.title)
 
         # Fix up tags, if broken
-        tags_in = taglist_str((tags_in or '') + DELIM + result.tags(redirect=tag_redirect, error=tag_error))
+        tags_exclude = set(taglist((tags_except or '').split(DELIM)))
+        tags_fetched = result.tags(keywords=tags_fetch, redirect=tag_redirect, error=tag_error)
+        tags = taglist_str((tags_in or '') + DELIM + tags_fetched,
+                           lambda ss: [s for s in ss if s not in tags_exclude])
+        LOGDBG('tags: [%s]', tags)
 
         # Process description
         desc = (desc if desc is not None else result.desc) or ''
@@ -808,7 +820,7 @@ class BukuDb:
 
             qry = 'INSERT INTO bookmarks(URL, metadata, tags, desc, flags) VALUES (?, ?, ?, ?, ?)'
             with self.lock:
-                self.cur.execute(qry, (url, title, tags_in, desc, flagset))
+                self.cur.execute(qry, (url, title, tags, desc, flagset))
                 if not delay_commit:
                     self.conn.commit()
                 if self.chatty:
@@ -4346,13 +4358,16 @@ def fetch_data(
     return FetchResult(page_url, title=page_title, desc=page_desc, keywords=page_keys, fetch_status=page_status)
 
 
-def parse_tags(keywords=[]):
+def parse_tags(keywords=[], *, edit_input=False):
     """Format and get tag string from tokens.
 
     Parameters
     ----------
     keywords : list
         List of tags to parse. Default is empty list.
+    edit_input : bool
+        Whether the taglist is an edit input (i.e. may start with '+'/'-').
+        Defaults to False.
 
     Returns
     -------
@@ -4367,14 +4382,16 @@ def parse_tags(keywords=[]):
     if keywords is None:
         return None
 
-    if not keywords or not keywords[0]:
+    tagstr = ' '.join(s for s in keywords if s)
+    if not tagstr:
         return DELIM
 
-    tags = DELIM
+    if edit_input and keywords[0] in ('+', '-'):
+        return keywords[0] + parse_tags(keywords[1:])
 
     # Cleanse and get the tags
-    tagstr = ' '.join(keywords)
     marker = tagstr.find(DELIM)
+    tags = DELIM
 
     while marker >= 0:
         token = tagstr[0:marker]
@@ -5668,7 +5685,7 @@ def parse_range(tokens: Optional[str | Sequence[str] | Set[str]],  # Optional[st
 
 
 # main starts here
-def main():
+def main(argv=sys.argv[1:], *, program_name=os.path.basename(sys.argv[0])):
     """Main."""
     global ID_STR, ID_DB_STR, MUTE_STR, URL_STR, DESC_STR, DESC_WRAP, TAG_STR, TAG_WRAP, PROMPTMSG
     # readline should not be loaded when buku is used as a library
@@ -5686,26 +5703,26 @@ def main():
     pipeargs = []
     colorstr_env = os.getenv('BUKU_COLORS')
 
-    if len(sys.argv) >= 2 and sys.argv[1] != '--nostdin':
+    if argv and argv[0] != '--nostdin':
         try:
-            piped_input(sys.argv, pipeargs)
+            piped_input(argv, pipeargs)
         except KeyboardInterrupt:
             pass
 
         # If piped input, set argument vector
         if pipeargs:
-            sys.argv = pipeargs
+            argv = pipeargs
 
     # Setup custom argument parser
     argparser = ExtendedArgumentParser(
+        prog=program_name,
         description='''Bookmark manager like a text-based mini-web.
 
 POSITIONAL ARGUMENTS:
       KEYWORD              search keywords''',
         formatter_class=argparse.RawTextHelpFormatter,
         usage='''buku [OPTIONS] [KEYWORD [KEYWORD ...]]''',
-        add_help=False
-    )
+        add_help=False)
     hide = argparse.SUPPRESS
 
     argparser.add_argument('keywords', nargs='*', metavar='KEYWORD', help=hide)
@@ -5716,8 +5733,9 @@ POSITIONAL ARGUMENTS:
 
     general_grp = argparser.add_argument_group(
         title='GENERAL OPTIONS',
-        description='''    -a, --add URL [tag, ...]
+        description='''    -a, --add URL [+|-] [tag, ...]
                          bookmark URL with comma-separated tags
+                         (prepend tags with '+' or '-' to use fetched tags)
     -u, --update [...]   update fields of an existing bookmark
                          accepts indices and ranges
                          refresh title and desc if no edit options
@@ -5913,11 +5931,11 @@ POSITIONAL ARGUMENTS:
     addarg('--db', nargs=1, help=hide)
 
     # Parse the arguments
-    args = argparser.parse_args()
+    args = argparser.parse_args(argv)
 
     # Show help and exit if help requested
     if args.help:
-        argparser.print_help(sys.stdout)
+        argparser.print_help()
         sys.exit(0)
 
     # By default, buku uses ANSI colors. As Windows does not really use them,
@@ -5972,7 +5990,7 @@ POSITIONAL ARGUMENTS:
     browse.override_text_browser = False
 
     # Fallback to prompt if no arguments
-    if len(sys.argv) <= 2 and (len(sys.argv) == 1 or (len(sys.argv) == 2 and args.nostdin)):
+    if argv in ([], ['--nostdin']):
         bdb = BukuDb()
         prompt(bdb, None)
         bdb.close_quit(0)
@@ -6056,15 +6074,7 @@ POSITIONAL ARGUMENTS:
         elif args.add is None:
             # Edit and add a new bookmark
             # Parse tags into a comma-separated string
-            if tags_in:
-                if tags_in[0] == '+':
-                    tags = '+' + parse_tags(tags_in[1:])
-                elif tags_in[0] == '-':
-                    tags = '-' + parse_tags(tags_in[1:])
-                else:
-                    tags = parse_tags(tags_in)
-            else:
-                tags = DELIM
+            tags = parse_tags(tags_in, edit_input=True)
 
             result = edit_rec(args.write, '', title_in, tags, desc_in)
             if result is not None:
@@ -6080,22 +6090,28 @@ POSITIONAL ARGUMENTS:
             bdb.close_quit(1)
 
         # Parse tags into a comma-separated string
-        tags = DELIM
-        keywords = args.add
-        if tags_in is not None:
-            if tags_in[0] == '+':
-                if len(tags_in) > 1:
-                    # The case: buku -a url tag1, tag2 --tag + tag3, tag4
-                    tags_in = tags_in[1:]
-                    # In case of add, args.add may have URL followed by tags
-                    # Add delimiter as url+tags may not end with one
-                    keywords = args.add + [DELIM] + tags_in
+        # --add may have URL followed by tags
+        keywords_except, keywords = [], args.add[1:]
+        # taglists are taken from --add (starting from 2nd value) and from --tags
+        # if taglist starts with '-', its contents are excluded from resulting tags
+        # if BOTH taglists is are either empty or start with '+'/'-', fetched tags are included
+        if keywords and keywords[0] == '-':
+            keywords, keywords_except = [], keywords[1:]
+        tags_add = (not keywords or keywords[0] == '+')
+        if tags_add:
+            keywords = keywords[1:]
+        if tags_in:
+            # note: need to add a delimiter as url+tags may not end with one
+            if tags_in[0] == '-':
+                keywords_except += [DELIM] + tags_in[1:]
+            elif tags_in[0] == '+':
+                keywords += [DELIM] + tags_in[1:]
             else:
-                keywords = args.add + [DELIM] + tags_in
+                keywords += [DELIM] + tags_in
+                tags_add = False
 
-        if len(keywords) > 1:  # args.add is URL followed by optional tags
-            tags = parse_tags(keywords[1:])
-
+        tags, tags_except = parse_tags(keywords), parse_tags(keywords_except)
+        tags, tags_except = ((s if s and s != DELIM else None) for s in [tags, tags_except])
         url = args.add[0]
         edit_aborted = False
 
@@ -6109,8 +6125,11 @@ POSITIONAL ARGUMENTS:
         if edit_aborted is False:
             if args.suggest:
                 tags = bdb.suggest_similar_tag(tags)
-            bdb.add_rec(url, title_in, tags, desc_in, _immutable(args), delay_commit=False, fetch=not args.offline,
-                        url_redirect=args.url_redirect, tag_redirect=tag_redirect, tag_error=tag_error, del_error=del_error)
+            network_test = args.url_redirect or tag_redirect or tag_error or del_error
+            fetch = not args.offline and (network_test or tags_add or title_in is None)
+            bdb.add_rec(url, title_in, tags, desc_in, _immutable(args), delay_commit=False, fetch=fetch,
+                        tags_fetch=tags_add, tags_except=tags_except, url_redirect=args.url_redirect,
+                        tag_redirect=tag_redirect, tag_error=tag_error, del_error=del_error)
 
     # Search record
     search_results = None
@@ -6280,15 +6299,8 @@ POSITIONAL ARGUMENTS:
         url_in = (args.url[0] if args.url else None)
 
         # Parse tags into a comma-separated string
-        if tags_in:
-            if tags_in[0] == '+':
-                tags = '+' + parse_tags(tags_in[1:])
-            elif tags_in[0] == '-':
-                tags = '-' + parse_tags(tags_in[1:])
-            else:
-                tags = parse_tags(tags_in)
-        else:
-            tags = None
+        tags = parse_tags(tags_in, edit_input=True)
+        tags = (None if tags == DELIM else tags)
 
         # No arguments to --update, update all
         if not args.update:

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -87,9 +87,9 @@ def test_get_PoolManager(m_myproxy):
 @pytest.mark.parametrize(
     "keywords, exp_res",
     [
-        ("", DELIM),
-        (",", DELIM),
-        ("tag1, tag2", ",t a g 1,t a g 2,"),
+        ([""], DELIM),
+        ([","], DELIM),
+        (["tag1, tag2"], ",tag1,tag2,"),
         ([" a tag , ,   ,  ,\t,\n,\r,\x0b,\x0c"], ",a tag,"),  # whitespaces
         ([",,,,,"], ","),  # empty tags
         (["\"tag\",'tag',tag"], ",\"tag\",'tag',tag,"),  # escaping quotes
@@ -114,14 +114,17 @@ def test_get_PoolManager(m_myproxy):
         ),
     ],
 )
-def test_parse_tags(keywords, exp_res):
+@pytest.mark.parametrize('prefix', [None, '', '+', '-'])
+def test_parse_tags(prefix, keywords, exp_res):
     """test func."""
     import buku
 
+    edit_input = prefix is not None
     if keywords is None:
-        assert buku.parse_tags(keywords) is None
+        assert buku.parse_tags(keywords, edit_input=edit_input) is None
     else:
-        assert buku.parse_tags(keywords) == exp_res
+        _keywords = ([] if not prefix else [prefix]) + keywords
+        assert buku.parse_tags(_keywords, edit_input=edit_input) == (prefix or '') + exp_res
 
 
 def test_parse_tags_no_args():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,140 @@
+from unittest import mock
+from io import StringIO
+import pytest
+
+import buku
+
+
+@pytest.fixture
+def stdin(monkeypatch):
+    with monkeypatch.context():
+        monkeypatch.setattr('sys.stdin', (buffer := StringIO()))
+        yield buffer
+
+@pytest.fixture
+def BukuDb():
+    with mock.patch('buku.BukuDb') as cls:
+        cls.return_value.close_quit.side_effect = SystemExit
+        yield cls
+
+@pytest.fixture
+def bdb(BukuDb):
+    yield BukuDb.return_value
+
+@pytest.fixture
+def piped_input():
+    with mock.patch('buku.piped_input') as fn:
+        yield fn
+
+@pytest.fixture
+def prompt():
+    with mock.patch('buku.prompt') as fn:
+        yield fn
+
+@pytest.fixture
+def exit():
+    with mock.patch('sys.exit', side_effect=SystemExit) as fn:
+        yield fn
+
+
+def test_version(BukuDb, piped_input, capsys):
+    with pytest.raises(SystemExit):
+        buku.main(['--version'])
+    assert capsys.readouterr().out.splitlines() == [buku.__version__]
+
+def test_usage(BukuDb, piped_input, monkeypatch, capsys):
+    with pytest.raises(SystemExit):
+        buku.main(['--unknown'], program_name='buku')
+    BukuDb.assert_not_called()
+    assert capsys.readouterr().err.splitlines() == [
+        'usage: buku [OPTIONS] [KEYWORD [KEYWORD ...]]',
+        'buku: error: unrecognized arguments: --unknown',
+    ]
+
+@pytest.mark.parametrize('argv', [['--help'], ['foo', 'bar', '--help']])
+def test_help(BukuDb, exit, piped_input, argv):
+    with mock.patch('buku.ExtendedArgumentParser.print_help') as print_help:
+        with pytest.raises(SystemExit):
+            buku.main(argv)
+    BukuDb.assert_not_called()
+    print_help.assert_called_with()
+    exit.assert_called_with(0)
+
+@pytest.mark.parametrize('argv', [[], ['--nostdin']])
+def test_prompt(BukuDb, bdb, piped_input, prompt, argv):
+    with pytest.raises(SystemExit):
+        buku.main(argv)
+    piped_input.assert_not_called()
+    BukuDb.assert_called_with()
+    prompt.assert_called_with(bdb, None)
+    bdb.close_quit.assert_called_with(0)
+
+
+@pytest.mark.parametrize('fetch_params', [
+    {'offline': True},
+    {'url_redirect': True},
+    {'tag_redirect': True, 'tag_error': True},
+    {'url_redirect': True, 'tag_redirect': 'redirect', 'tag_error': 'error'},
+    {'url_redirect': True, 'tag_redirect': 'redirect', 'del_range': [], 'del_error': range(400, 600)},
+    {'url_redirect': True, 'tag_redirect': 'redirect', 'tag_error': 'error',
+     'del_range': ['400-404', '500'], 'del_error': {400, 401, 402, 403, 404, 500}},
+])
+@pytest.mark.parametrize('value_params', [
+    {'add_tags': ['foo,bar', 'baz'], 'tags_fetch': False, 'tags_in': ',bar baz,foo,', 'title': ''},
+    {'tag': ['foo', 'bar,baz'], 'tags_fetch': False, 'tags_in': ',baz,foo bar,', 'title': 'Custom Title'},
+    {'add_tags': ['+', 'foo', 'bar', 'baz'], 'tags_in': ',foo bar baz,', 'comment': ''},
+    {'tag': ['+', 'foo,bar,baz'], 'tags_in': ',bar,baz,foo,', 'comment': 'Custom Description'},
+    {'add_tags': ['-', 'foo', 'baz', 'baz'], 'tags_except': ',foo baz baz,', 'immutable': False},
+    {'tag': ['-', 'foo,', ',baz,', ',baz'], 'tags_except': ',baz,foo,', 'immutable': True},
+    {'add_tags': ['foo,baz,bar'], 'tag': ['baz,qux'],
+     'tags_fetch': False, 'tags_in': ',bar,baz,foo,qux,'},
+    {'add_tags': ['+', 'foo,baz,bar'], 'tag': ['baz,', 'qux,'],
+     'tags_fetch': False, 'tags_in': ',bar,baz,foo,qux,'},
+    {'add_tags': ['foo,baz,', 'bar,'], 'tag': ['+', 'baz,qux'],
+     'tags_fetch': False, 'tags_in': ',bar,baz,foo,qux,'},
+    {'add_tags': ['-', 'foo,baz,bar,'], 'tag': ['baz,', 'qux,'],
+     'tags_fetch': False, 'tags_in': ',baz,qux,', 'tags_except': ',bar,baz,foo,'},
+    {'add_tags': ['foo,baz,', 'bar,'], 'tag': ['-', 'baz,qux'],
+     'tags_fetch': False, 'tags_in': ',bar,baz,foo,', 'tags_except': ',baz,qux,'},
+    {'add_tags': ['-', 'foo,baz,bar,'], 'tag': ['-', 'baz,', 'qux,'], 'tags_except': ',bar,baz,foo,qux,'},
+    {'add_tags': ['-', 'foo,baz,', 'bar,'], 'tag': ['+', 'baz,', 'qux,'],
+     'tags_in': ',baz,qux,', 'tags_except': ',bar,baz,foo,'},
+    {'add_tags': ['+', 'foo,baz,', 'bar,'], 'tag': ['-', 'baz,', 'qux,'],
+     'tags_in': ',bar,baz,foo,', 'tags_except': ',baz,qux,'},
+])
+def test_add(stdin, bdb, prompt, value_params, fetch_params):
+    _test_add(bdb, prompt, **value_params, **fetch_params)
+
+def _test_add(bdb, prompt, *, add_tags=[], tag=[], tags_fetch=True, tags_in=None, tags_except=None,
+              title=None, comment=None, immutable=None, offline=False, url_redirect=False,
+              tag_redirect=False, tag_error=False, del_range=None, del_error=None):
+    argv = ['--add', (url := 'https://example.com/')] + add_tags
+    if tag:
+        argv += ['--tag'] + tag
+    if title is not None:
+        argv += ['--title', title]
+    if comment is not None:
+        argv += ['--comment', comment]
+    if immutable is not None:
+        argv += ['--immutable', str(int(immutable))]
+    if offline:
+        argv += ['--offline']
+    if url_redirect:
+        argv += ['--url-redirect']
+    if tag_redirect:
+        argv += ['--tag-redirect'] + ([] if isinstance(tag_redirect, bool) else [tag_redirect])
+    if tag_error:
+        argv += ['--tag-error'] + ([] if isinstance(tag_error, bool) else [tag_error])
+    if del_error:
+        argv += ['--del-error'] + del_range
+    with pytest.raises(SystemExit):
+        buku.main(argv)
+    network_test = url_redirect or tag_redirect or tag_error or del_error
+    fetch = not offline and (network_test or tags_fetch or title is None)
+    bdb.add_rec.assert_called_with(
+        url, title, tags_in, comment, immutable, delay_commit=False, fetch=fetch,
+        tags_fetch=tags_fetch, tags_except=tags_except, url_redirect=url_redirect,
+        tag_redirect=tag_redirect, tag_error=tag_error, del_error=del_error)
+    bdb.searchdb.assert_not_called()
+    prompt.assert_not_called()
+    bdb.close_quit.assert_called_with(0)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,8 @@
 from unittest import mock
+import os
+
 from urllib3 import HTTPResponse
+
 from buku import FetchResult
 
 
@@ -19,3 +22,11 @@ def _add_rec(db, *args, **kw):
 
 def _tagset(s):
     return set(x for x in str(s or '').lower().split(',') if x)
+
+def append(buffer, text):
+    pos = buffer.tell()
+    try:
+        buffer.seek(0, os.SEEK_END)
+        return buffer.write(text)
+    finally:
+        buffer.seek(pos)


### PR DESCRIPTION
Addressing the case discussed in #759

* When running an `--add` command, tag lists supplied via `--tag` or `--add` (2nd value and further) can be prepended with `+` or `-`, same as when editing tags
* `+` means tags in the list should be included in the resulting record tags
* `-` means tags in the list should be _excluded_ from the resulting record tags (this is applied last)
* If either of the tag lists is non-empty (even if it's just a `,` or a blank string), but doesn't start with `+`/`-`, it has same effect as `+` except it _overrides_ fetched tags
* These rules apply to both tag lists identically (if both/neither start with `-`, they're simply combined)
* If there's no reason to fetch remote data (i.e. user supplied title and description, applied tags override, and did not request any network tests), the fetch will be skipped

Also added a few CLI tests (mainly related to the changes)