### PR TITLE
implementing random bookmark(s) selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ SEARCH OPTIONS:
                            excludes entries with tags after ' - '
                            list all tags, if no search keywords
       -x, --exclude [...]  omit records matching specified keywords
+      --random [N]         output random bookmarks out of the selection (default 1)
       --order fields [...] comma-separated list of fields to order the output by
                            (prepend with '+'/'-' to choose sort direction)
 
@@ -534,7 +535,20 @@ PROMPT KEYS:
 42. Update all bookmarks matching the search by updating the URL if the server responds with a permanent redirect, deleting the bookmark if the server responds with HTTP error 400, 401, 402, 403, 404 or 500, or adding a tag shaped like `http:{}` in case of any other HTTP error; then export those affected by such changes into an HTML file, marking deleted records as well as old URLs for those replaced by redirect.
 
         $ buku -S ://wikipedia.net -u --url-redirect --tag-error --del-error 400-404,500 --export-on --export backup.html
-43. More **help**:
+
+43. Print out a single **random** bookmark:
+
+        $ buku --random --print
+
+44. Print out 3 **random** bookmarks **ordered** by title (reversed) and url:
+
+        $ buku --random 3 --order ,-title,+url --print
+
+45. Print out a single **random** bookmark matching **search** criteria, and **export** into a Markdown file (in DB order):
+
+        $ buku --random -S kernel debugging --export random.md
+
+46. More **help**:
 
         $ buku -h
         $ man buku

--- a/buku
+++ b/buku
@@ -29,6 +29,7 @@ import locale
 import logging
 import os
 import platform
+import random
 import re
 import shutil
 import signal
@@ -461,7 +462,7 @@ class BookmarkVar(NamedTuple):
     def taglist(self) -> List[str]:
         return [x for x in self.tags_raw.split(',') if x]
 
-bookmark_vars = lambda xs: (BookmarkVar(*x) for x in xs)
+bookmark_vars = lambda xs: ((x if isinstance(x, BookmarkVar) else BookmarkVar(*x)) for x in xs)
 
 
 class BukuDb:
@@ -2102,6 +2103,8 @@ class BukuDb:
         is_range : bool
             A range is passed using low and high arguments.
             An index is ignored if is_range is True.
+        order : list of str
+            Order description (fields from JSON export or DB, prepended with '+'/'-' for ASC/DESC).
 
         Returns
         -------
@@ -2186,12 +2189,13 @@ class BukuDb:
                 LOGERR('No matching index %s', index)
                 return False
 
+            single_record = len(results) == 1
             if self.json is None:
                 print_rec_with_filter(results, self.field_filter)
             elif self.json:
-                write_string_to_file(format_json(results, True, self.field_filter), self.json)
+                write_string_to_file(format_json(results, single_record, field_filter=self.field_filter), self.json)
             else:
-                print_json_safe(results, True, self.field_filter)
+                print_json_safe(results, single_record, field_filter=self.field_filter)
 
             return True
         else:  # Show all entries
@@ -2327,14 +2331,14 @@ class BukuDb:
             raise ValueError("Original tag cannot contain delimiter ({}).".format(DELIM))
 
         orig = delim_wrap(orig)
-        newtags = parse_tags([DELIM.join(new)])
+        newtags = taglist_str(DELIM.join(new))
 
         if orig == newtags:
             raise ValueError("Original and replacement tags are the same.")
 
         # Remove original tag from DB if new tagset reduces to delimiter
         if newtags == DELIM:
-            if not self.delete_tag_at_index(0, orig):
+            if not self.delete_tag_at_index(0, orig, chatty=self.chatty):
                 raise RuntimeError("Tag deletion failed.")
 
         # Update bookmarks with original tag
@@ -2528,17 +2532,12 @@ class BukuDb:
             return False
 
         if index == 0:
-            with self.lock:
-                qry = 'SELECT id from bookmarks ORDER BY RANDOM() LIMIT 1'
-                self.cur.execute(qry)
-                result = self.cur.fetchone()
-
-            # Return if no entries in DB
-            if result is None:
+            max_id = self.get_max_id()
+            if not max_id:
                 print('No bookmarks added yet ...')
                 return False
 
-            index = result[0]
+            index = random.randint(1, max_id)
             LOGDBG('Opening random index %d', index)
 
         qry = 'SELECT URL FROM bookmarks WHERE id = ? LIMIT 1'
@@ -2553,7 +2552,8 @@ class BukuDb:
 
         return False
 
-    def exportdb(self, filepath: str, resultset: Optional[List[BookmarkVar]] = None, order: List[str] = ['id']) -> bool:
+    def exportdb(self, filepath: str, resultset: Optional[List[BookmarkVar]] = None,
+                 order: List[str] = ['id'], pick: Optional[int] = None) -> bool:
         """Export DB bookmarks to file.
         Exports full DB, if resultset is None.
         Additionally, if run after a (batch) update with export_on, only export those records.
@@ -2576,6 +2576,10 @@ class BukuDb:
         resultset : list of tuples
             List of results to export. Use `None` to get current DB.
             Ignored if run after a (batch) update with export_on.
+        order : list of str
+            Order description (fields from JSON export or DB, prepended with '+'/'-' for ASC/DESC).
+        pick : int, optional
+            Reduce the export to a random subset of up to given (positive) size. Default is None.
 
 
         Returns
@@ -2596,11 +2600,14 @@ class BukuDb:
         if self._to_export is not None:
             _resultset = dict(old)
             _resultset.update({x.url: x for x in resultset if x.url in old})
-            resultset = list(_resultset.values())
+            resultset = self._sort(_resultset.values(), order)
             self._to_export = None
             if not resultset:
                 print('No records to export')
                 return False
+
+        if pick and pick < len(resultset):
+            resultset = self._sort(random.sample(resultset, pick), order)
 
         if os.path.exists(filepath):
             resp = read_in(filepath + ' exists. Overwrite? (y/n): ')
@@ -3353,6 +3360,8 @@ Webpage: https://github.com/jarun/buku
         file.write('''
 PROMPT KEYS:
     1-N                    browse search result indices and/or ranges
+    R [N]                  print out N random search results
+                           (or random bookmarks if negative or N/A)
     O [id|range [...]]     open search results/indices in GUI browser
                            toggle try GUI browser if no arguments
     a                      open all results in browser
@@ -4658,9 +4667,10 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
             pass
         return
 
+    skip_print = False
     while True:
-        if new_results or nav == 'n':
-            count = 0
+        if (new_results or nav == 'n') and not skip_print:
+            count = next_index
 
             if results:
                 total_results = len(results)
@@ -4674,8 +4684,11 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
                     print('%d-%d/%d' % (cur_index + 1, next_index, total_results))
                 else:
                     print('No more results')
+                    new_results = False
             else:
                 print('0 results')
+                new_results = False
+        skip_print = False
 
         try:
             nav = read_in(PROMPTMSG)
@@ -4690,6 +4703,17 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
 
         # show the next set of results from previous search
         if nav == 'n':
+            continue
+
+        if (m := re.match(r'^R(?: (-)?([0-9]+))?$', nav)) and (n := int(m[2] or 1)) > 0:
+            skip_print = True
+            if results and not m[1]:  # from search results
+                picked = random.sample(results, min(n, len(results)))
+            else:                     # from all bookmarks
+                ids = range(1, 1 + (bdb.get_max_id() or 0))
+                picked = bdb.get_rec_all_by_ids(random.sample(ids, min(n, len(ids))))
+            for row in bdb._sort(picked, order):
+                print_single_rec(row, columns=columns)
             continue
 
         # search ANY match with new keywords
@@ -4852,7 +4876,7 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
                 if index < 0 or index >= count:
                     print('No matching index %s' % nav)
                     continue
-                browse(results[index + cur_index][1])
+                browse(results[index][1])
             elif '-' in nav:
                 try:
                     vals = [int(x) for x in nav.split('-')]
@@ -4861,7 +4885,7 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
 
                     for _id in range(vals[0]-1, vals[-1]):
                         if 0 <= _id < count:
-                            browse(results[_id + cur_index][1])
+                            browse(results[_id][1])
                         else:
                             print('No matching index %d' % (_id + 1))
                 except ValueError:
@@ -5897,6 +5921,7 @@ POSITIONAL ARGUMENTS:
                          excludes entries with tags after ' - '
                          list all tags, if no search keywords
     -x, --exclude [...]  omit records matching specified keywords
+    --random [N]         output random bookmarks out of the selection (default 1)
     --order fields [...] comma-separated list of fields to order the output by
                          (prepend with '+'/'-' to choose sort direction)''')
     addarg = search_grp.add_argument
@@ -5907,6 +5932,7 @@ POSITIONAL ARGUMENTS:
     addarg('--markers', action='store_true', help=hide)
     addarg('-t', '--stag', nargs='*', help=hide)
     addarg('-x', '--exclude', nargs='*', help=hide)
+    addarg('--random', nargs='?', type=int, const=1, help=hide)
     addarg('--order', nargs='+', help=hide)
 
     # ------------------------
@@ -6282,6 +6308,10 @@ POSITIONAL ARGUMENTS:
 
     update_search_results = False
     if search_results:
+        if args.random and args.random < len(search_results):
+            search_results = bdb._sort(random.sample(search_results, args.random), order)
+        single_record = args.random == 1  # matching print_rec() behaviour
+
         oneshot = args.np
 
         # Open all results in browser right away if args.oa
@@ -6297,16 +6327,16 @@ POSITIONAL ARGUMENTS:
                 (args.update is not None and not args.update)):
             oneshot = True
 
-        if args.json is None and not args.format:
+        if args.json is None and not args.format and not args.random:
             num = 10 if not args.count else args.count
             prompt(bdb, search_results, noninteractive=oneshot, deep=args.deep, markers=args.markers, order=order, num=num)
         elif args.json is None:
             print_rec_with_filter(search_results, field_filter=args.format)
         elif args.json:
-            write_string_to_file(format_json(search_results, field_filter=args.format), args.json)
+            write_string_to_file(format_json(search_results, single_record, field_filter=args.format), args.json)
         else:
             # Printing in JSON format is non-interactive
-            print_json_safe(search_results, field_filter=args.format)
+            print_json_safe(search_results, single_record, field_filter=args.format)
 
         # Export the results, if opted
         if args.export and not (args.update is not None and export_on):
@@ -6386,7 +6416,14 @@ POSITIONAL ARGUMENTS:
 
     # Print record
     if args.print is not None:
-        if not args.print:
+        try:
+            id_range = list(parse_range(args.print) or []) or range(1, 1 + (bdb.get_max_id() or 0))
+        except ValueError:
+            LOGERR('Invalid index or range to print')
+            bdb.close_quit(1)
+        if args.random and args.random < len(id_range):
+            bdb.print_rec(random.sample(id_range, args.random), order=order)
+        elif not args.print:
             if args.count:
                 search_results = bdb.list_using_id(order=order)
                 prompt(bdb, search_results, noninteractive=args.np, num=args.count, order=order)
@@ -6397,18 +6434,7 @@ POSITIONAL ARGUMENTS:
                 search_results = bdb.list_using_id(args.print, order=order)
                 prompt(bdb, search_results, noninteractive=args.np, num=args.count, order=order)
             else:
-                try:
-                    ids = set()
-                    for idx in args.print:
-                        if is_int(idx):
-                            ids |= {int(idx)}
-                        elif '-' in idx:
-                            vals = [int(x) for x in idx.split('-')]
-                            ids |= set(range(vals[0], vals[-1] + 1))
-                except ValueError:
-                    LOGERR('Invalid index or range to print')
-                    bdb.close_quit(1)
-                bdb.print_rec(ids, order=order)
+                bdb.print_rec(id_range, order=order)
 
     # Replace a tag in DB
     if args.replace is not None:
@@ -6423,7 +6449,7 @@ POSITIONAL ARGUMENTS:
 
     # Export bookmarks
     if args.export and not search_opted and not export_on:
-        bdb.exportdb(args.export[0], order=order)
+        bdb.exportdb(args.export[0], order=order, pick=args.random)
 
     # Import bookmarks
     if args.importfile is not None:

--- a/buku.1
+++ b/buku.1
@@ -192,6 +192,9 @@ List all tags alphabetically, if no arguments. The usage count (number of bookma
 .BI \-x " " \--exclude " keyword [...]"
 Exclude bookmarks matching the specified keywords. Works with --sany, --sall, --sreg and --stag.
 .TP
+.BI \--random " [N]"
+Output random bookmarks out of the selection (1 unless amount is specified).
+.TP
 .BI \--order " fields [...]"
 Order printed/exported records by the given fields (from DB or JSON). You can specify sort direction for each by prepending '+'/'-' (default is '+').
 .SH ENCRYPTION OPTIONS
@@ -930,6 +933,31 @@ Update all bookmarks matching the search by updating the URL if the server respo
 .B buku -S ://wikipedia.net -u --url-redirect --tag-error --del-error 400-404,500 --export-on --export backup.html
 .EE
 .PP
+.IP 43. 4
+Print out a single \fBrandom\fR bookmark:
+.PP
+.EX
+.IP
+.B buku --random
+.EE
+.PP
+.IP 44. 4
+Print out 3 \fBrandom\fR bookmarks \fBordered\fR by title (reversed) and url:
+.PP
+.EX
+.IP
+.B buku --random 3 --order ,-title,+url
+.EE
+.PP
+.IP 45. 4
+Print out a single \fBrandom\fR bookmark matching \fBsearch\fR criteria, and \fBexport\fR into a Markdown file (in DB order):
+.PP
+.EX
+.IP
+.B buku --random -S kernel debugging --export random.md
+.EE
+.PP
+
 
 .SH AUTHOR
 Arun Prakash Jana <engineerarun@gmail.com>

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -4,7 +4,6 @@
 import os
 import sys
 from typing import Union  # NOQA; type: ignore
-from urllib.parse import urlparse
 
 from flask.cli import FlaskGroup
 from flask_admin import Admin
@@ -23,10 +22,10 @@ from flask import __version__ as flask_version  # type: ignore
 from flask import current_app, redirect, request, url_for
 
 try:
-    from . import api, views
+    from . import api, views, util
     from response import Response
 except ImportError:
-    from bukuserver import api, views
+    from bukuserver import api, views, util
     from bukuserver.response import Response
 
 
@@ -117,7 +116,7 @@ def create_app(db_file=None):
         """Shell context definition."""
         return {'app': app, 'bukudb': bukudb}
 
-    app.jinja_env.filters['netloc'] = lambda x: urlparse(x).netloc  # pylint: disable=no-member
+    app.jinja_env.filters.update(util.JINJA_FILTERS)
 
     admin = Admin(
         app, name='buku server', template_mode='bootstrap3',

--- a/bukuserver/templates/bukuserver/bookmark_details_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_details_modal.html
@@ -1,6 +1,17 @@
 {% extends 'admin/model/modals/details.html' %}
 {% import 'bukuserver/lib.html' as buku with context %}
 
+{% block header_text %}
+  <h3>
+    {% if request.args.get('id') == 'random' %}
+    <button id="modal-random" class="btn btn-default" title="Pick another">
+      <span class="fa fa-eye glyphicon glyphicon-repeat"></span>
+    </button>
+    {% endif %}
+    <a href="{{ url_for('bookmark.details_view', id=model.id, url=request.args.url) }}">{{_gettext('View Record')}} #{{model.id}}</a>
+  </h3>
+{% endblock %}
+
 {% block tail %}
   {{ super() }}
   {{ buku.details_formatting('.modal') }}

--- a/bukuserver/templates/bukuserver/bookmarks_list.html
+++ b/bukuserver/templates/bukuserver/bookmarks_list.html
@@ -6,9 +6,22 @@
   {{ buku.close_if_popup() }}
 {% endblock %}
 
+{% block model_menu_bar_before_filters %}
+  {{ super() }}
+  {% if data %}
+    {% set _random = url_for('bookmark.details_view', modal=True, id='random', url=return_url, **(request.args|flt)) %}
+    <li><a id="random" data-target="#fa_modal_window" data-toggle="modal" href="{{ _random }}">Random</a></li>
+  {% endif %}
+{% endblock %}
+
 {% block tail %}
   {{ super() }}
   {{ buku.script('buku_filter.js') }}
   {{ buku.focus(None) }}
   {{ buku.link_saved() }}
+  <script>
+    $(document).on('click', `#modal-random`, function() {
+      $(`#fa_modal_window .modal-content`).load($(`#random`).attr('href'));
+    });
+  </script>
 {% endblock %}

--- a/bukuserver/util.py
+++ b/bukuserver/util.py
@@ -1,0 +1,17 @@
+from collections import Counter
+from urllib.parse import urlparse
+import re
+
+get_netloc = lambda x: urlparse(x).netloc  # pylint: disable=no-member
+select_filters = lambda args: {k: v for k, v in args.items() if re.match(r'flt.*_', k)}
+
+JINJA_FILTERS = {'flt': select_filters, 'netloc': get_netloc}
+
+
+def chunks(arr, n):
+    n = max(1, n)
+    return [arr[i : i + n] for i in range(0, len(arr), n)]
+
+def sorted_counter(keys, *, min_count=0):
+    data = Counter(keys)
+    return Counter({k: v for k, v in sorted(data.items()) if v > min_count})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -379,19 +379,19 @@ def test_env_theme(theme, client):
 
 _DICT = {
     'en': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Home', 'Bookmarks', 'Tags', 'Statistic'],
-           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['List (1)', 'Create', 'Add Filter', '10 items'],
+           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['List (1)', 'Create', 'Random', 'Add Filter', '10 items'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['View Record', 'Edit Record'],
            f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},
     'de': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Start', 'Bookmarks', 'Tags', 'Statistic'],
-           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Liste (1)', 'Erstellen', 'Filter hinzufügen', '10 Elemente'],
+           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Liste (1)', 'Erstellen', 'Random', 'Filter hinzufügen', '10 Elemente'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Eintrag ansehen', 'Eintrag bearbeiten'],
            f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},
     'fr': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Accueil', 'Bookmarks', 'Tags', 'Statistic'],
-           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Liste (1)', 'Créer', 'Ajouter un filtre', '10 items'],
+           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Liste (1)', 'Créer', 'Random', 'Ajouter un filtre', '10 items'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Afficher L\'enregistrement', 'Modifier enregistrement'],
            f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},
     'ru': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Главная', 'Bookmarks', 'Tags', 'Statistic'],
-           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Список (1)', 'Создать', 'Добавить Фильтр', '10 элементы'],
+           f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['Список (1)', 'Создать', 'Random', 'Добавить Фильтр', '10 элементы'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Просмотр записи', 'Редактировать запись'],
            f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},
 }


### PR DESCRIPTION
Ability to poll for a random bookmark (without immediately opening it in a browser).  
Usecase: “what do I read next?” (+bukuserver)

### Screenshots

<details><summary>CLI</summary>

(can be used with print, search and export)
![CLI samples](https://github.com/user-attachments/assets/62bf8a2d-cc4d-4313-987a-ee7644a3fd7c)
</details>
<details><summary>interactive shell</summary>

(`R` shows a random result, `R 3` – 3 results, `R -2` shows 2 random records ignoring last/current search)
![shell samples](https://github.com/user-attachments/assets/cccea34c-e6d5-4e91-8021-d4b0799e2efd)
</details>
<details><summary>webUI</summary>

(the Random button searches within currently viewed list)
![random button](https://github.com/user-attachments/assets/c93a98ff-2e8d-4c90-b2d4-35de19a7d001)
(the "Pick another" button is only present when viewing a random entry; it refreshes the modal contents which rerolls the ID)
![random modal](https://github.com/user-attachments/assets/1e1a6236-1e66-4fed-98a7-e71135907e46)
(the View Record header link is identical to the one used in "successful update" message; it's handy if you want to edit a [random] entry, and then switch back to the list you were viewing)
![record page link](https://github.com/user-attachments/assets/343dc2bc-c46f-4b0d-b6fd-5ced18dc862d)
</details>
