### PR TITLE
Updating supported Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,6 @@ jobs:
       - image: python:3.12-slim
     <<: *lint-template
 
-  py38:
-    docker:
-      - image: python:3.8-slim
-    <<: *test-template
-
   py39:
     docker:
       - image: python:3.9-slim
@@ -69,6 +64,11 @@ jobs:
   py312:
     docker:
       - image: python:3.12-slim
+    <<: *test-template
+
+  py313:
+    docker:
+      - image: python:3.13-slim
     <<: *test-template
 
 #  package-and-publish:
@@ -126,11 +126,11 @@ workflows:
   CircleCI:
     jobs: &all-tests
       - lint
-      - py38
       - py39
       - py310
       - py311
       - py312
+      - py313
 
   nightly:
     triggers:

--- a/buku
+++ b/buku
@@ -135,7 +135,7 @@ TEXT_BROWSERS = ['elinks', 'links', 'links2', 'lynx', 'w3m', 'www-browser']
 IGNORE_FF_BOOKMARK_FOLDERS = frozenset(["placesRoot", "bookmarksMenuFolder"])
 PERMANENT_REDIRECTS = {301, 308}
 
-# IntSet: TypeAlias = Set[int] | range      # TODO: use after dropping 3.8 & 3.9
+# IntSet: TypeAlias = Set[int] | range      # TODO: use after dropping 3.9
 # Ints: TypeAlias = Sequence[int] | IntSet
 # IntOrInts: TypeAlias = int | Ints
 # T = TypeVar('T')

--- a/setup.py
+++ b/setup.py
@@ -104,11 +104,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
         'Topic :: Utilities'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pylint,flake8
+envlist = py39,py310,py311,py312,py313,pylint,flake8
 
 [flake8]
 max-line-length = 139
@@ -43,11 +43,6 @@ markers =
 usedevelop = true
 deps = pytest
 
-[testenv:py38]
-extras = tests
-commands =
-    pytest --cov buku -vv -m "not non_tox" {posargs}
-
 [testenv:py39]
 extras = tests
 commands =
@@ -64,6 +59,11 @@ commands =
     pytest --cov buku -vv -m "not non_tox" {posargs}
 
 [testenv:py312]
+extras = tests
+commands =
+    pytest --cov buku -vv -m "not non_tox" {posargs}
+
+[testenv:py313]
 extras = tests
 commands =
     pytest --cov buku -vv -m "not non_tox" {posargs}


### PR DESCRIPTION
resolves #780:
* added Python 3.13 to package setup file, as well as `tox` & CI configs
* removed Python 3.8 from those same files

I did not switch default `tox` Python version from 3.12 yet since both 3.12 & 3.13 have the same official status but 3.13 was only recently released. (The tests with `-e py313` seem to be running alright locally though.)