### PR TITLE
added support for all form parameters in bookmarklet endpoint

### DIFF
--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -277,9 +277,11 @@ class BookmarkletView(MethodView):  # pylint: disable=too-few-public-methods
         url = request.args.get('url')
         title = request.args.get('title')
         description = request.args.get('description')
+        tags = request.args.get('tags')
+        fetch = request.args.get('fetch')
 
         bukudb = getattr(flask.g, 'bukudb', get_bukudb())
         rec_id = bukudb.get_rec_id(url)
         if rec_id:
             return redirect(url_for('bookmark.edit_view', id=rec_id))
-        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description))
+        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description, tags=tags, fetch=fetch))

--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -6,7 +6,7 @@
   {{ buku.set_lang() }}
   {{ buku.limit_navigation_if_popup() }}
   {{ buku.script('bookmark.js') }}
-  {{ buku.fetch_checkbox() }}
+  {{ buku.fetch_checkbox(form.fetch.data) }}
   {{ buku.focus() }}
   {{ buku.link_saved() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/bookmark_create_modal.html
+++ b/bukuserver/templates/bukuserver/bookmark_create_modal.html
@@ -10,6 +10,6 @@
 {% block tail %}
   {{ super() }}
   {{ buku.script('bookmark.js') }}
-  {{ buku.fetch_checkbox() }}
+  {{ buku.fetch_checkbox(form.fetch.data) }}
   {{ buku.focus('.modal-body') }}
 {% endblock %}

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -209,11 +209,13 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
             form.url.data = request.args.get('link', form.url.data)
             form.title.data = request.args.get('title', form.title.data)
             form.description.data = request.args.get('description', form.description.data)
+            form.tags.data = request.args.get('tags', form.tags.data)
+            form.fetch.data = request.args.get('fetch', request.data.get('fetch', True))
         return form
 
     def create_model(self, form):
         try:
-            model = types.SimpleNamespace(id=None, url=None, title=None, tags=None, description=None, fetch=True)
+            model = types.SimpleNamespace(id=None, url=None, title=None, tags=None, description=None, fetch=None)
             form.populate_obj(model)
             vars(model).pop("id")
             self._on_model_change(form, model, True)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -168,12 +168,14 @@ def test_bookmarklet_view(bukudb, client, exists, uri, tab, args):
     (True, '', 'Some description'),
     (False, 'Some title', ''),
     (False, '', 'Some description'),
+    (None, 'Some title', ''),
+    (None, '', 'Some description'),
 ])
 def test_create_and_fetch(bukudb, monkeypatch, client, fetch, title, desc):
     query = {'link': 'http://example.com', 'title': title, 'description': desc, 'tags': 'foo, bar, baz'}
-    _title, _desc = 'Sample site', 'Foo bar baz'
-    if fetch:
-        query['fetch'] = 'on'
+    _title, _desc = 'Fetched title', 'Fetched description'
+    if fetch is not None:
+        query['fetch'] = 'on' if fetch else ''
 
     with mock_fetch(title=_title, desc=_desc):
         response = client.post('/bookmark/new/', data=query, follow_redirects=True)
@@ -182,8 +184,8 @@ def test_create_and_fetch(bukudb, monkeypatch, client, fetch, title, desc):
     [bookmark] = bukudb.get_rec_all()
     assert_bookmark(bookmark, {
         'link': query['link'], 'tags': ',bar,baz,foo,',
-        'title': (title or _title) if fetch else title,
-        'description': (desc or _desc) if fetch else desc,
+        'title': (title or _title) if fetch or fetch is None else title,  # defaults to True
+        'description': (desc or _desc) if fetch or fetch is None else desc,
     })
 
 


### PR DESCRIPTION
Something which I had in my workspace for a week or so…

This doesn't affect current Bukuserver behaviour, but it extends the bookmarklet API to support all fields of the Create Bookmark form; which could be used by custom (e.g. user-made) bookmarklets.