### PR TITLE
added 'netloc-tag' to URL_RENDER_MODE values

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -112,7 +112,7 @@ The following are os env config variables available for bukuserver.
 | --- | --- | --- |
 | PER_PAGE | bookmarks per page | positive integer [default: 10] |
 | SECRET_KEY | [flask secret key](https://flask.palletsprojects.com/config/#SECRET_KEY) | string [default: os.urandom(24)] |
-| URL_RENDER_MODE | url render mode | `full` or `netloc` [default: `full`] |
+| URL_RENDER_MODE | url render mode | `full`, `netloc` or `netloc-tag` [default: `full`] |
 | DB_FILE | full path to db file | path string [default: standard path for buku] |
 | READONLY | read-only mode | boolean [default: `false`] |
 | DISABLE_FAVICON | disable bookmark [favicons](https://wikipedia.org/wiki/Favicon) | boolean [default: `true`] ([here's why](#why-favicons-are-disabled-by-default))|

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -90,7 +90,7 @@ def create_app(db_file=None):
     per_page = per_page if per_page > 0 else views.DEFAULT_PER_PAGE
     app.config['BUKUSERVER_PER_PAGE'] = per_page
     url_render_mode = os.getenv('BUKUSERVER_URL_RENDER_MODE', views.DEFAULT_URL_RENDER_MODE)
-    if url_render_mode not in ('full', 'netloc'):
+    if url_render_mode not in ('full', 'netloc', 'netloc-tag'):
         url_render_mode = views.DEFAULT_URL_RENDER_MODE
     app.config['BUKUSERVER_URL_RENDER_MODE'] = url_render_mode
     app.config['SECRET_KEY'] = os.getenv('BUKUSERVER_SECRET_KEY') or os.urandom(24)

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -135,7 +135,7 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
             res += [f'<span class="netloc"> ({link(netloc, url_for_index_view_netloc)})</span>']
         if not parsed_url.scheme:
             res += [f'<span class="link">{escape(model.url)}</span>']
-        elif self.url_render_mode is None or self.url_render_mode == 'full':
+        elif self.url_render_mode == 'full':
             res += [f'<span class="link">{link(model.url, model.url, new_tab=new_tab)}</span>']
         tag_links = []
         if netloc and self.url_render_mode != 'netloc' and url_for_index_view_netloc:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -300,7 +300,7 @@ def test_env_per_page(bukudb, app, client, total, per_page, pages, last_page):
 @pytest.mark.slow
 @pytest.mark.parametrize('new_tab', [False, True, None])
 @pytest.mark.parametrize('favicons', [False, True, None])
-@pytest.mark.parametrize('mode', ['full', 'netloc', None])
+@pytest.mark.parametrize('mode', ['full', 'netloc', 'netloc-tag', None])
 def test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab):
     url, netloc, title, desc, tags = 'http://example.com', 'example.com', 'Sample site', 'Foo bar baz', ',bar,baz,foo,'
     _add_rec(bukudb, url, title, tags, desc)
@@ -323,6 +323,8 @@ def test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab):
     suffix = f'<div class="tag-list">{netloc_tag}{"".join(tags)}</div><div class="description">{desc}</div> </td>'
     if mode == 'netloc':
         assert cell == f'{prefix}<span class="netloc"> (<a href="/bookmark/?flt0_url_netloc_match={netloc}">{netloc}</a>)</span>{suffix}'
+    elif mode == 'netloc-tag':
+        assert cell == prefix + suffix
     else:
         assert cell == f'{prefix}<span class="link"><a href="{url}"{target}>{url}</a></span>{suffix}'
 


### PR DESCRIPTION
Adding a "hybrid" option for `BUKUSERVER_URL_RENDER_MODE=` setting (it's effectively identical to `netloc`, except that the netloc-filter link is rendered as a "tag" – just like when using the `full` option). …It just looks cleaner, IMO.

@jarun alternatively we could replace the `netloc` option with this – it does pretty much the exact same thing, after all; just retaining design used by the other option for the same element.

### Screenshots

![netloc-tag](https://github.com/user-attachments/assets/d0f907cd-6a74-4258-bd79-dd885307a781)

The other options still work as before:

<details><summary><code>full</code>/unset</summary>

![full](https://github.com/user-attachments/assets/f61a9049-b355-474a-a2ab-d3604a4431ff)
</details>
<details><summary><code>netloc</code></summary>

![netloc](https://github.com/user-attachments/assets/424f1329-b5c0-43c3-9576-40d9522816ef)
</details>
