### PR TITLE
fixed error caused by the fallback implementation of gettext

### DIFF
--- a/bukuserver/__init__.py
+++ b/bukuserver/__init__.py
@@ -4,7 +4,8 @@ try:  # as per Flask-Admin-1.6.1
     except ImportError:
         from flask_babel import gettext, ngettext, pgettext, lazy_gettext, lazy_pgettext, LazyString
 except ImportError:
-    from flask_admin.babel import gettext, ngettext, lazy_gettext
+    from flask_admin.babel import gettext as _gettext, ngettext, lazy_gettext
+    gettext = lambda s, *a, **kw: (s if not kw else _gettext(s, *a, **kw))
     pgettext = lambda ctx, s, *a, **kw: gettext(s, *a, **kw)
     lazy_pgettext = lambda ctx, s, *a, **kw: lazy_gettext(s, *a, **kw)
     LazyString = lambda func, *args, **kwargs: func(*args, **kwargs)


### PR DESCRIPTION
…I have no idea how I've missed this, but apparently the [fallback `gettext()` implementation from flask-admin](https://github.com/pallets-eco/flask-admin/blob/v1.6.1/flask_admin/babel.py#L8-L9) causes an error when using parameters in a template :sweat_smile: