### PR TITLE
[jarun#807] fixed import in single-parent-folder-tag mode

### DIFF
--- a/buku
+++ b/buku
@@ -4014,35 +4014,21 @@ def import_html(html_soup: BeautifulSoup, add_parent_folder_as_tag: bool, newtag
             desc = comment_tag.find(string=True, recursive=False)
 
         if add_parent_folder_as_tag:
-            # add parent folder as tag
-            if use_nested_folder_structure:
-                # New method that would generalize for else case to
-                # structure of folders
-                # dt
-                #   h3 (folder name)
-                #   dl
-                #       dt
-                #           a (could be h3, and continue recursively)
-                parents = tag.find_parents('dl')
-                for parent in parents:
-                    header = parent.find_previous_sibling('h3')
-                    if header:
-                        if tag.has_attr('tags'):
-                            tag['tags'] += (DELIM + strip_delim(header.text))
-                        else:
-                            tag['tags'] = strip_delim(header.text)
-            else:
-                # could be its folder or not
-                possible_folder = tag.find_previous('h3')
-                # get list of tags within that folder
-                tag_list = tag.parent.parent.find_parent('dl')
-
-                if ((possible_folder) and possible_folder.parent in list(tag_list.parents)):
-                    # then it's the folder of this bookmark
+            # New method that would generalize for else case to
+            # structure of folders
+            # dt
+            #   h3 (folder name)
+            #   dl
+            #       dt
+            #           a (could be h3, and continue recursively)
+            parents = tag.find_parents('dl')
+            for parent in (parents if use_nested_folder_structure else parents[:1]):
+                header = parent.find_previous_sibling('h3')
+                if header:
                     if tag.has_attr('tags'):
-                        tag['tags'] += (DELIM + strip_delim(possible_folder.text))
+                        tag['tags'] += (DELIM + strip_delim(header.text))
                     else:
-                        tag['tags'] = strip_delim(possible_folder.text)
+                        tag['tags'] = strip_delim(header.text)
 
         # add unique tag if opted
         if newtag:

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -791,7 +791,7 @@ def test_import_html_and_add_parent():
             [
                 ("http://example11.com", None, ",folder11,", None, 0, True, False),
                 ("http://example121.com", None, ",folder121,", None, 0, True, False),
-                ("http://example12.com", None, None, None, 0, True, False),
+                ("http://example12.com", None, ",folder12,", None, 0, True, False),
                 ("http://example13.com", None, ",folder13 (blah blah),tag3,tag4,", None, 0, True, False),
             ],
         ),


### PR DESCRIPTION
fixes #807:
* when "add single, direct parent folder" tagging mode is enabled, the import behaves consistently with the "add all parent folders" mode (i.e. it applies parent tag to _**all**_ immediate children, not just the _**first one**_)

### Example

<details><summary>input file</summary>

```html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!-- This is an automatically generated file.
     It will be read and overwritten.
     DO NOT EDIT! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks</H1>
<DL><p>
    <DT><H3>Testing</H3>
    <DL><p>
        <DT><H3>Testing Nested</H3>
        <DL><p>
            <DT><H3>Testing Nested Nested</H3>
            <DL><p>
                <DT><H3>Test</H3>
                <DL><p>
                    <DT><A HREF="https://en.wikipedia.org/wiki/Main_Page#/media/File:The_Death_of_General_Mercer_at_the_Battle_of_Princeton_January_3_1777.jpeg">The Death of General Mercer at the Battle of Princeton January 3 1777 - Wikipedia, the free encyclopedia</A>
                </DL><p>
                <DT><A HREF="https://en.wikipedia.org/wiki/Romania">Romania - Wikipedia</A>
            </DL><p>
            <DT><A HREF="https://en.wikipedia.org/wiki/Main_Page">Wikipedia, the free encyclopedia</A>
        </DL><p>
        <DT><A HREF="https://en.wikipedia.org/wiki/December_(George_Winston_album)">December (George Winston album) - Wikipedia</A>
    </DL><p>
</DL><p>
```
</details>

(before)
![before](https://github.com/user-attachments/assets/aa52645a-56af-4c46-88a8-08eaec7d041d)
(after)
![after](https://github.com/user-attachments/assets/542c9a20-c03a-498d-b703-7504cf9c91b2)
