### PR TITLE
Removing URL shorten/expand functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ To get started right away, jump to the [Quickstart](#quickstart) section. `buku`
 - Store bookmarks with auto-fetched title, tags and description
 - Auto-import from Firefox, Google Chrome, Chromium and MS Edge
 - Open bookmarks and search results in browser
-- Shorten, expand URLs
 - Browse cached page from the Wayback Machine
 - Text editor integration
 - Lightweight, clean interface, custom colors
@@ -272,8 +271,6 @@ POWER TOYS:
                            options, including removed info
                            (requires --update and --export; specific
                            HTTP response filter can be provided)
-      --shorten index|URL  fetch shortened url from tny.im service
-      --expand index|URL   expand a tny.im shortened url
       --cached index|URL   browse a cached page from Wayback Machine
       --offline            add a bookmark without connecting to web
       --suggest            show similar tags when adding bookmarks
@@ -516,11 +513,7 @@ PROMPT KEYS:
 36. List bookmarks with **immutable title**:
 
         $ buku -S immutable
-37. **Shorten URL** www.google.com and the URL at index 20:
-
-        $ buku --shorten www.google.com
-        $ buku --shorten 20
-38. **Append, remove tags at prompt** (taglist index to the left, bookmark index to the right):
+37. **Append, remove tags at prompt** (taglist index to the left, bookmark index to the right):
 
         // append tags at taglist indices 4 and 6-9 to existing tags in bookmarks at indices 5 and 2-3
         buku (? for help) g 4 9-6 >> 5 3-2
@@ -530,43 +523,43 @@ PROMPT KEYS:
         buku (? for help) g > 5 3-2
         // remove tags at taglist indices 4 and 6-9 from tags in bookmarks at indices 5 and 2-3
         buku (? for help) g 4 9-6 << 5 3-2
-39. List bookmarks with **colored output**:
+38. List bookmarks with **colored output**:
 
         $ buku --colors oKlxm -p
-40. Add a bookmark after following all permanent redirects, but only if the server doesn't respond with an error (and there's no network failure)
+39. Add a bookmark after following all permanent redirects, but only if the server doesn't respond with an error (and there's no network failure)
 
         $ buku --add http://wikipedia.net --url-redirect --del-error
         2. Wikipedia
            > https://www.wikipedia.org/
            + Wikipedia is a free online encyclopedia, created and edited by volunteers around the world and hosted by the Wikimedia Foundation.
-41. Add a bookmark with tag `http redirect` if the server responds with a permanent redirect, or tag shaped like `http 404` on an error response:
+40. Add a bookmark with tag `http redirect` if the server responds with a permanent redirect, or tag shaped like `http 404` on an error response:
 
         $ buku --add http://wikipedia.net/notfound --tag-redirect 'http redirect' --tag-error 'http {}'
         [ERROR] [404] Not Found
         3. Not Found
            > http://wikipedia.net/notfound
            # http 404,http redirect
-42. Update all bookmarks matching the search by updating the URL if the server responds with a permanent redirect, deleting the bookmark if the server responds with HTTP error 400, 401, 402, 403, 404 or 500, or adding a tag shaped like `http:{}` in case of any other HTTP error; then export those affected by such changes into an HTML file, marking deleted records as well as old URLs for those replaced by redirect.
+41. Update all bookmarks matching the search by updating the URL if the server responds with a permanent redirect, deleting the bookmark if the server responds with HTTP error 400, 401, 402, 403, 404 or 500, or adding a tag shaped like `http:{}` in case of any other HTTP error; then export those affected by such changes into an HTML file, marking deleted records as well as old URLs for those replaced by redirect.
 
         $ buku -S ://wikipedia.net -u --url-redirect --tag-error --del-error 400-404,500 --export-on --export backup.html
 
-43. Print out a single **random** bookmark:
+42. Print out a single **random** bookmark:
 
         $ buku --random --print
 
-44. Print out 3 **random** bookmarks **ordered** by netloc (reversed), title and url:
+43. Print out 3 **random** bookmarks **ordered** by netloc (reversed), title and url:
 
         $ buku --random 3 --order ,-netloc,title,+url --print
 
-45. Print out a single **random** bookmark matching **search** criteria, and **export** into a Markdown file (in DB order):
+44. Print out a single **random** bookmark matching **search** criteria, and **export** into a Markdown file (in DB order):
 
         $ buku --random -S kernel debugging --export random.md
 
-46. Swap positions of records #4 and #5:
+45. Swap positions of records #4 and #5:
 
         $ buku --swap 4 5
 
-47. More **help**:
+46. More **help**:
 
         $ buku -h
         $ man buku

--- a/buku
+++ b/buku
@@ -3134,84 +3134,11 @@ n: don't add parent folder as tag
             index: Optional[int] = None,
             url: Optional[str] = None,
             shorten: bool = True) -> Optional[str]:
-        """Shorten a URL using Google URL shortener.
+        """Shorten/expand a URL using the tny.im service.
 
-        Parameters
-        ----------
-        index : int, optional (if URL is provided)
-            DB index of the bookmark with the URL to shorten. Default is None.
-        url : str, optional (if index is provided)
-            URL to shorten.
-        shorten : bool
-            True to shorten, False to expand. Default is False.
-
-        Returns
-        -------
-        str
-            Shortened url on success, None on failure.
+        Tny.im is no longer available; don't use this method.
         """
-
-        global MYPROXY
-
-        if not index and not url:
-            LOGERR('Either a valid DB index or URL required')
-            return None
-
-        if index:
-            with self.lock:
-                self.cur.execute('SELECT url FROM bookmarks WHERE id = ? LIMIT 1', (index,))
-                results = self.cur.fetchall()
-            if not results:
-                return None
-
-            url = results[0][0]
-
-        from urllib.parse import quote_plus as qp
-
-        url = url or ''
-        urlbase = 'https://tny.im/yourls-api.php?action='
-        if shorten:
-            _u = urlbase + 'shorturl&format=simple&url=' + qp(url)
-        else:
-            _u = urlbase + 'expand&format=simple&shorturl=' + qp(url)
-
-        if MYPROXY is None:
-            gen_headers()
-
-        ca_certs = os.getenv('BUKU_CA_CERTS', default=CA_CERTS)
-        if MYPROXY:
-            manager = urllib3.ProxyManager(
-                MYPROXY,
-                num_pools=1,
-                headers=MYHEADERS,
-                cert_reqs='CERT_REQUIRED',
-                ca_certs=ca_certs)
-        else:
-            manager = urllib3.PoolManager(num_pools=1,
-                                          headers={'User-Agent': USER_AGENT},
-                                          cert_reqs='CERT_REQUIRED',
-                                          ca_certs=ca_certs)
-
-        try:
-            r = manager.request(
-                'POST',
-                _u,
-                headers={
-                    'content-type': 'application/json',
-                    'User-Agent': USER_AGENT}
-            )
-        except Exception as e:
-            LOGERR(e)
-            manager.clear()
-            return None
-
-        if r.status != 200:
-            LOGERR('[%s] %s', r.status, r.reason)
-            return None
-
-        manager.clear()
-
-        return r.data.decode(errors='replace')
+        warn('\'BukuDb.tnyfy_url()\' no longer works due to the takedown of tny.im service.', DeprecationWarning)
 
     def browse_cached_url(self, arg):
         """Open URL at index or URL.
@@ -6010,8 +5937,6 @@ POSITIONAL ARGUMENTS:
                          options, including removed info
                          (requires --update and --export; specific
                          HTTP response filter can be provided)
-    --shorten index|URL  fetch shortened url from tny.im service
-    --expand index|URL   expand a tny.im shortened url
     --cached index|URL   browse a cached page from Wayback Machine
     --offline            add a bookmark without connecting to web
     --suggest            show similar tags when adding bookmarks
@@ -6040,8 +5965,6 @@ POSITIONAL ARGUMENTS:
     addarg('--tag-error', nargs='?', const=True, default=False, help=hide)
     addarg('--del-error', nargs='*', help=hide)
     addarg('--export-on', nargs='*', help=hide)
-    addarg('--shorten', nargs=1, help=hide)
-    addarg('--expand', nargs=1, help=hide)
     addarg('--cached', nargs=1, help=hide)
     addarg('--offline', action='store_true', help=hide)
     addarg('--suggest', action='store_true', help=hide)
@@ -6490,26 +6413,6 @@ POSITIONAL ARGUMENTS:
             except ValueError:
                 LOGERR('Invalid index or range to open')
                 bdb.close_quit(1)
-
-    # Shorten URL
-    if args.shorten:
-        if is_int(args.shorten[0]):
-            shorturl = bdb.tnyfy_url(index=int(args.shorten[0]))
-        else:
-            shorturl = bdb.tnyfy_url(url=args.shorten[0])
-
-        if shorturl:
-            print(shorturl)
-
-    # Expand URL
-    if args.expand:
-        if is_int(args.expand[0]):
-            url = bdb.tnyfy_url(index=int(args.expand[0]), shorten=False)
-        else:
-            url = bdb.tnyfy_url(url=args.expand[0], shorten=False)
-
-        if url:
-            print(url)
 
     # Try to fetch URL from Wayback Machine
     if args.cached:

--- a/buku.1
+++ b/buku.1
@@ -12,7 +12,6 @@ is a command-line utility to store, tag, search and organize bookmarks.
   * Store bookmarks with auto-fetched title, tags and description
   * Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, and MS Edge
   * Open bookmarks and search results in browser
-  * Shorten, expand URLs
   * Browse cached page from the Wayback Machine
   * Text editor integration
   * Lightweight, clean interface, custom colors
@@ -318,20 +317,6 @@ when fetching an URL causes any (given) HTTP error, delete/do not add it. (Use a
 .TP
 .BI \--export-on " [...]"
 export records affected by the above options, including removed info (requires --update and --export; specific HTTP response filter can be provided).
-.TP
-.BI \--shorten " index|URL"
-Shorten the URL at DB
-.I index
-or an independent
-.I URL
-using the tny.im URL shortener service.
-.TP
-.BI \--expand " index|URL"
-Expand the URL at DB
-.I index
-or an independent
-.I URL
-shortened using tny.im.
 .TP
 .BI \--cached " index|URL"
 Browse the latest cached version of the URL at DB
@@ -866,16 +851,6 @@ List bookmarks with \fBimmutable title\fR:
 .EE
 .PP
 .IP 37. 4
-\fBShorten\fR the URL www.google.com and the URL at index 20:
-.PP
-.EX
-.IP
-.B buku --shorten www.google.com
-.br
-.B buku --shorten 20
-.EE
-.PP
-.IP 38. 4
 \fBAppend, remove tags at prompt\fR (taglist index to the left, bookmark index to the right):
 .PP
 .EX
@@ -897,7 +872,7 @@ List bookmarks with \fBimmutable title\fR:
 .B buku (? for help) g 4 9-6 << 5 3-2
 .EE
 .PP
-.IP 39. 4
+.IP 38. 4
 List bookmarks with \fBcolored output\fR:
 .PP
 .EX
@@ -905,7 +880,7 @@ List bookmarks with \fBcolored output\fR:
 .B $ buku --colors oKlxm -p
 .EE
 .PP
-.IP 40. 4
+.IP 39. 4
 Add a bookmark after following all permanent redirects, but only if the server doesn't respond with an error (and there's no network failure)
 .PP
 .EX
@@ -919,7 +894,7 @@ Add a bookmark after following all permanent redirects, but only if the server d
    + Wikipedia is a free online encyclopedia, created and edited by volunteers around the world and hosted by the Wikimedia Foundation.
 .EE
 .PP
-.IP 41. 4
+.IP 40. 4
 Add a bookmark with tag 'http redirect' if the server responds with a permanent redirect, or tag shaped like 'http 404' on an error response:
 .PP
 .EX
@@ -935,7 +910,7 @@ Add a bookmark with tag 'http redirect' if the server responds with a permanent 
    # http 404,http redirect
 .EE
 .PP
-.IP 42. 4
+.IP 41. 4
 Update all bookmarks matching the search by updating the URL if the server responds with a permanent redirect, deleting the bookmark if the server responds with HTTP error 400, 401, 402, 403, 404 or 500, or adding a tag shaped like 'http:{}' in case of any other HTTP error; then export those affected by such changes into an HTML file, marking deleted records as well as old URLs for those replaced by redirect.
 .PP
 .EX
@@ -943,7 +918,7 @@ Update all bookmarks matching the search by updating the URL if the server respo
 .B buku -S ://wikipedia.net -u --url-redirect --tag-error --del-error 400-404,500 --export-on --export backup.html
 .EE
 .PP
-.IP 43. 4
+.IP 42. 4
 Print out a single \fBrandom\fR bookmark:
 .PP
 .EX
@@ -951,7 +926,7 @@ Print out a single \fBrandom\fR bookmark:
 .B buku --random
 .EE
 .PP
-.IP 44. 4
+.IP 43. 4
 Print out 3 \fBrandom\fR bookmarks \fBordered\fR by netloc (reversed), title and url:
 .PP
 .EX
@@ -959,7 +934,7 @@ Print out 3 \fBrandom\fR bookmarks \fBordered\fR by netloc (reversed), title and
 .B buku --random 3 --order ,-netloc,title,+url
 .EE
 .PP
-.IP 45. 4
+.IP 44. 4
 Print out a single \fBrandom\fR bookmark matching \fBsearch\fR criteria, and \fBexport\fR into a Markdown file (in DB order):
 .PP
 .EX
@@ -967,7 +942,7 @@ Print out a single \fBrandom\fR bookmark matching \fBsearch\fR criteria, and \fB
 .B buku --random -S kernel debugging --export random.md
 .EE
 .PP
-.IP 46. 4
+.IP 45. 4
 Swap positions of records #4 and #5:
 .PP
 .EX

--- a/bukuserver/response.py
+++ b/bukuserver/response.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 from enum import Enum
 from flask import jsonify
-from flask_api.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
+from flask_api.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND, HTTP_410_GONE
 
 OK, FAIL = 0, 1
 
@@ -9,6 +9,7 @@ OK, FAIL = 0, 1
 class Response(Enum):
     SUCCESS = (HTTP_200_OK, "Success.")
     FAILURE = (HTTP_400_BAD_REQUEST, "Failure.")
+    REMOVED = (HTTP_410_GONE, "Functionality no longer available.")
     INPUT_NOT_VALID = (HTTP_400_BAD_REQUEST, "Input data not valid.")
     BOOKMARK_NOT_FOUND = (HTTP_404_NOT_FOUND, "Bookmark not found.")
     TAG_NOT_FOUND = (HTTP_404_NOT_FOUND, "Tag not found.")

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -55,9 +55,7 @@ def refresh_bookmark(rec_id: Union[int, None]):
     return Response.from_flag(result_flag)
 
 
-def get_tiny_url(rec_id):
-    url = getattr(flask.g, 'bukudb', api.get_bukudb()).tnyfy_url(rec_id)
-    return Response.SUCCESS(data={'url': url}) if url else Response.FAILURE()
+get_tiny_url = lambda rec_id: Response.REMOVED()
 
 
 _BOOL_VALUES = {'true': True, '1': True, 'false': False, '0': False}

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -13,14 +13,13 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from random import shuffle
 from unittest import mock
 
-from genericpath import exists
 import pytest
 import yaml
 from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 from buku import PERMANENT_REDIRECTS, BukuDb, FetchResult, BookmarkVar, bookmark_vars, parse_tags, prompt
-from tests.util import mock_http, mock_fetch, _add_rec, _tagset
+from tests.util import mock_fetch, _add_rec, _tagset
 
 
 def get_temp_dir_path():
@@ -770,18 +769,6 @@ class TestBukuDb(unittest.TestCase):
                 self.assertEqual(from_db[3], parse_tags(["__02,__03,jaźń"]))
             elif title == "test":
                 self.assertEqual(from_db[3], parse_tags(["test,tes,est,__04"]))
-
-    def test_tnyfy_url(self):
-        tny, full = 'http://tny.im/yt', 'https://www.google.com'
-        # shorten a well-known url
-        with mock_http(tny, status=200):
-            shorturl = self.bdb.tnyfy_url(url=full, shorten=True)
-        self.assertEqual(shorturl, tny)
-
-        # expand a well-known short url
-        with mock_http(full, status=200):
-            url = self.bdb.tnyfy_url(url=tny, shorten=False)
-        self.assertEqual(url, full)
 
     # def test_browse_by_index(self):
     # self.fail()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -196,7 +196,7 @@ def test_create_and_fetch(bukudb, monkeypatch, client, fetch, title, desc):
     ('_continue_editing', '/bookmark/edit/', {'id': '1', 'url': '/bookmark/'}),
 ])
 def test_create_redirect(client, redirect, uri, args):
-    query = {'link': 'http://example.com', 'title': '', 'description': '', 'tags': '', redirect: 'on'}
+    query = {'link': 'http://example.com', 'title': '', 'description': '', 'tags': '', 'fetch': '', redirect: 'on'}
 
     response = client.post('/bookmark/new/', data=query, follow_redirects=True)
     dom = assert_response(response, uri, args=args)


### PR DESCRIPTION
fixes #815:
* removing broken functionality that relied on the decommissioned tny.im service