### PR TITLE
Fixing docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex \
   && rm -rf /buku
 
 HEALTHCHECK --interval=1m --timeout=10s \
-  CMD nc -z localhost ${BUKUSERVER_PORT} || exit 1
+  CMD nc -z 127.0.0.1 ${BUKUSERVER_PORT} || exit 1
 
 ENTRYPOINT gunicorn --bind 0.0.0.0:${BUKUSERVER_PORT} "bukuserver.server:create_app()"
 EXPOSE ${BUKUSERVER_PORT}


### PR DESCRIPTION
fixes #810:
* Docker healthcheck now reports working server as healthy

### Screenshots

(before)
![before](https://github.com/user-attachments/assets/cabefcc6-873b-4fe4-95af-2c8d9f2db46e)
(after)
![after](https://github.com/user-attachments/assets/a5f845d9-8332-4799-a808-20a69e9007bb)
