### PR TITLE
support for retaining bookmarks order on deletion + printing multiline descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ GENERAL OPTIONS:
                            if no arguments:
                            - delete results when used with search
                            - otherwise delete all bookmarks
+      --retain-order       prevents reordering after deleting a bookmark
       -h, --help           show this information and exit
       -v, --version        show the program version and exit
 

--- a/buku
+++ b/buku
@@ -4962,23 +4962,23 @@ def print_single_rec(row: BookmarkVar, idx: int=0, columns: int=0):  # NOQA
             return
 
         INDENT = 5
-        ln_num = 1
         fillwidth = columns - INDENT
+        desc_lines = [s for line in row.desc.splitlines()
+                        for s in textwrap.wrap(line, width=fillwidth) or ['']]
+        TR = str.maketrans(',-', '-,')  # we want breaks after commas rather than hyphens
+        tag_lines = textwrap.wrap(row.tags.translate(TR), width=fillwidth)
 
-        for line in textwrap.wrap(row.desc.replace('\n', ''), width=fillwidth):
-            if ln_num == 1:
+        for idx, line in enumerate(desc_lines):
+            if idx == 0:
                 print(DESC_STR % line, end='')
-                ln_num += 1
             else:
                 print(DESC_WRAP % (' ' * INDENT, line))
 
-        ln_num = 1
-        for line in textwrap.wrap(row.tags.replace('\n', ''), width=fillwidth):
-            if ln_num == 1:
-                print(TAG_STR % line, end='')
-                ln_num += 1
+        for idx, line in enumerate(tag_lines):
+            if idx == 0:
+                print(TAG_STR % line.translate(TR), end='')
             else:
-                print(TAG_WRAP % (' ' * INDENT, line))
+                print(TAG_WRAP % (' ' * INDENT, line.translate(TR)))
         print()
     except UnicodeEncodeError:
         str_list = []

--- a/buku
+++ b/buku
@@ -1028,7 +1028,8 @@ class BukuDb:
             tag_redirect: bool | str = False,
             tag_error: bool | str = False,
             del_error: Optional[Set[int] | range] = None,             # Optional[IntSet]
-            export_on: Optional[Set[int] | range] = None) -> bool:    # Optional[IntSet]
+            export_on: Optional[Set[int] | range] = None,             # Optional[IntSet]
+            retain_order: bool = False) -> bool:
         """Update an existing record at (each) index.
 
         Update all records if index is 0 or empty, and url is not specified.
@@ -1066,6 +1067,9 @@ class BukuDb:
             Does NOT cause deletion of the bookmark on a network error.
         export_on : int{} | range, optional
             Limit the export to URLs returning one of given HTTP codes; store old URLs.
+        retain_order : bool
+            If True, bookmark deletion will not result in their order being changed
+            (multiple indices will be updated instead).
 
         Returns
         -------
@@ -1156,7 +1160,7 @@ class BukuDb:
             if result.fetch_status in export_on:  # storing the old record
                 self._to_export[url] = self.get_rec_by_id(index)
             LOGERR('HTTP error %s', result.fetch_status)
-            return self.delete_rec(index)
+            return self.delete_rec(index, retain_order=retain_order)
 
         if not indices and (arguments or tags_in):
             resp = read_in('Update ALL bookmarks? (y/n): ')
@@ -1194,7 +1198,7 @@ class BukuDb:
         if not arguments:  # no arguments => nothing to update
             if (tag_modified or network_test) and self.chatty:
                 self.print_rec(indices)
-            self.commit_delete()
+            self.commit_delete(retain_order=retain_order)
             return ret
 
         query = query[:-1]
@@ -1223,7 +1227,7 @@ class BukuDb:
                 LOGERR(e)
                 return False
             finally:
-                self.commit_delete()
+                self.commit_delete(retain_order=retain_order)
 
         return True
 
@@ -1239,7 +1243,8 @@ class BukuDb:
             update_title: bool = True,
             custom_url: Optional[str] = None,
             custom_tags: Optional[str] = None,
-            delay_delete: bool = False) -> bool:
+            delay_delete: bool = False,
+            retain_order: bool = False) -> bool:
         """Refresh ALL (or specified) records in the database.
 
         Fetch title for each bookmark from the web and update the records.
@@ -1278,6 +1283,9 @@ class BukuDb:
             Overwrite all tags. (Use to combine network testing with tags overwriting.)
         delay_delete : bool
             Delay scheduled deletions by del_error. (Use for network testing during update.)
+        retain_order : bool
+            If True, bookmark deletion will not result in their order being changed
+            (multiple indices will be updated instead).
 
         Returns
         -------
@@ -1456,17 +1464,18 @@ class BukuDb:
             if delay_delete:
                 self.conn.commit()
             else:
-                self.commit_delete()
+                self.commit_delete(retain_order=retain_order)
 
         return True
 
-    def commit_delete(self, apply: bool = True):
+    def commit_delete(self, apply: bool = True, retain_order: bool = False):
         """Commit delayed delete commands."""
         if apply and self._to_delete is not None:
             with self.lock:
                 for id in sorted(set(self._to_delete), reverse=True):
-                    self.delete_rec(id, delay_commit=True, chatty=False)
+                    self.delete_rec(id, delay_commit=True, chatty=False, retain_order=retain_order)
                 self.conn.commit()
+                self.cur.execute('VACUUM')
         self._to_delete = None
 
     def edit_update_rec(self, index, immutable=None):
@@ -1830,7 +1839,7 @@ class BukuDb:
             self.conn.commit()
         return True
 
-    def compactdb(self, index: int, delay_commit: bool = False):
+    def compactdb(self, index: int, delay_commit: bool = False, upto: Optional[int] = None, retain_order: bool = False):
         """When an entry at index is deleted, move the
         last entry in DB to index, if index is lesser.
 
@@ -1841,28 +1850,34 @@ class BukuDb:
         delay_commit : bool
             True if record should not be committed to the DB,
             leaving commit responsibility to caller. Default is False.
+        upto : int, optional
+            If specified, multiple indices are moved at once.
+        retain_order: bool
+            Shift indices of multiple records by 1 instead of replacing
+            the deleted record with the last one. Default is False.
         """
 
         # Return if the last index left in DB was just deleted
         max_id = self.get_max_id()
-        if not max_id:
+        if not max_id or (upto and upto < index):
             return
-
-        query1 = 'SELECT id, URL, metadata, tags, desc, flags FROM bookmarks WHERE id = ? LIMIT 1'
-        query2 = 'DELETE FROM bookmarks WHERE id = ?'
-        query3 = 'INSERT INTO bookmarks(id, URL, metadata, tags, desc, flags) VALUES (?, ?, ?, ?, ?, ?)'
 
         # NOOP if the just deleted index was the last one
         if max_id > index:
-            results = self._fetch(query1, max_id)
-            for row in results:
-                with self.lock:
-                    self.cur.execute(query2, (row.id,))
-                    self.cur.execute(query3, (index, row.url, row.title, row.tags_raw, row.desc, row.flags))
-                    if not delay_commit:
-                        self.conn.commit()
-                if self.chatty:
-                    print('Index %d moved to %d' % (row.id, index))
+            with self.lock:
+                if retain_order or (upto or 0) > index:
+                    step = (max(max_id - upto, upto + 1 - index) if not retain_order else
+                            1 if not upto else upto + 1 - index)
+                    self.cur.execute('UPDATE bookmarks SET id = id-? WHERE id >= ?', (step, index+step))
+                    msg = f'Indices {index+step}-{max_id} moved to {index}-{max_id-step}'
+                else:
+                    self.cur.execute('UPDATE bookmarks SET id = ? WHERE id = ?', (index, max_id))
+                    msg = f'Index {max_id} moved to {index}'
+                if not delay_commit:
+                    self.conn.commit()
+                    self.cur.execute('VACUUM')
+            if self.chatty:
+                print(msg)
 
     def delete_rec(
             self,
@@ -1872,6 +1887,7 @@ class BukuDb:
             is_range: bool = False,
             delay_commit: bool = False,
             chatty: Optional[bool] = None,
+            retain_order: bool = False,
     ) -> bool:
         """Delete a single record or remove the table if index is 0.
 
@@ -1891,6 +1907,9 @@ class BukuDb:
             leaving commit responsibility to caller. Default is False.
         chatty : Optional[bool]
             Override for self.chatty
+        retain_order: bool
+            Shift indices of multiple records instead of replacing
+            the deleted record with the last one. Default is False.
 
         Raises
         ------
@@ -1989,15 +2008,13 @@ class BukuDb:
                     if not self.cur.rowcount:
                         return False
 
-                # Compact DB by ascending order of index to ensure
-                # the existing higher indices move only once
+                # Compact DB in a single operation for the range
                 # Delayed commit is forced
                 with self.lock:
-                    for index in range(low, high + 1):
-                        self.compactdb(index, delay_commit=True)
-
+                    self.compactdb(low, upto=high, delay_commit=True, retain_order=retain_order)
                     if not delay_commit:
                         self.conn.commit()
+                        self.cur.execute('VACUUM')
             except IndexError:
                 LOGERR('No matching index')
                 return False
@@ -2024,9 +2041,10 @@ class BukuDb:
                     self.cur.execute(query, (index,))
                     if self.cur.rowcount == 1:
                         print('Index %d deleted' % index)
-                        self.compactdb(index, delay_commit=True)
+                        self.compactdb(index, delay_commit=True, retain_order=retain_order)
                         if not delay_commit:
                             self.conn.commit()
+                            self.cur.execute('VACUUM')
                     else:
                         LOGERR('No matching index %d', index)
                         return False
@@ -2039,7 +2057,7 @@ class BukuDb:
 
         return True
 
-    def delete_resultset(self, results):
+    def delete_resultset(self, results, retain_order=False):
         """Delete search results in descending order of DB index.
 
         Indices are expected to be unique and in ascending order.
@@ -2052,6 +2070,9 @@ class BukuDb:
         ----------
         results : list of tuples
             List of results to delete from DB.
+        retain_order: bool
+            Shift indices of multiple records instead of replacing
+            the deleted record with the last one. Default is False.
 
         Returns
         -------
@@ -2064,13 +2085,15 @@ class BukuDb:
                 return False
 
         # delete records in reverse order
+        ids = sorted(set(x[0] for x in results))
         with self.lock:
-            for pos, row in reversed(list(enumerate(results))):
-                self.delete_rec(row[0], delay_commit=True)
+            for pos, id in reversed(list(enumerate(ids))):
+                self.delete_rec(id, delay_commit=True, retain_order=retain_order)
 
                 # Commit at every 200th removal, counting from the end
                 if pos % 200 == 0:
                     self.conn.commit()
+                    self.cur.execute('VACUUM')
 
         return True
 
@@ -2094,6 +2117,7 @@ class BukuDb:
                 self.cur.execute('DELETE FROM bookmarks')
                 if not delay_commit:
                     self.conn.commit()
+                    self.cur.execute('VACUUM')
             return True
         except Exception as e:
             LOGERR('delete_rec_all(): %s', e)
@@ -2114,9 +2138,6 @@ class BukuDb:
             return False
 
         if self.delete_rec_all():
-            with self.lock:
-                self.cur.execute('VACUUM')
-                self.conn.commit()
             print('All bookmarks deleted')
             return True
 
@@ -5791,6 +5812,7 @@ POSITIONAL ARGUMENTS:
                          if no arguments:
                          - delete results when used with search
                          - otherwise delete all bookmarks
+    --retain-order       prevents reordering after deleting a bookmark
     -h, --help           show this information and exit
     -v, --version        show the program version and exit''')
     addarg = general_grp.add_argument
@@ -5798,6 +5820,7 @@ POSITIONAL ARGUMENTS:
     addarg('-u', '--update', nargs='*', help=hide)
     addarg('-w', '--write', nargs='?', const=get_system_editor(), help=hide)
     addarg('-d', '--delete', nargs='*', help=hide)
+    addarg('--retain-order', action='store_true', default=False, help=hide)
     addarg('-h', '--help', action='store_true', help=hide)
     addarg('-v', '--version', action='version', version=__version__, help=hide)
 
@@ -6284,7 +6307,7 @@ POSITIONAL ARGUMENTS:
         # prompt should be non-interactive
         # delete gets priority over update
         if args.delete is not None and not args.delete:
-            bdb.delete_resultset(search_results)
+            bdb.delete_resultset(search_results, retain_order=args.retain_order)
         elif args.update is not None and not args.update:
             update_search_results = True
 
@@ -6317,8 +6340,8 @@ POSITIONAL ARGUMENTS:
             _indices = ([] if 0 in _indices else _indices)
         if _indices is not None:
             bdb.update_rec(_indices, url_in, title_in, tags, desc_in, _immutable(args), threads=args.threads,
-                           url_redirect=args.url_redirect, tag_redirect=tag_redirect,
-                           tag_error=tag_error, del_error=del_error, export_on=export_on)
+                           url_redirect=args.url_redirect, tag_redirect=tag_redirect, tag_error=tag_error,
+                           del_error=del_error, export_on=export_on, retain_order=args.retain_order)
             if args.export and bdb._to_export is not None:
                 bdb.exportdb(args.export[0], order=order)
 
@@ -6332,22 +6355,17 @@ POSITIONAL ARGUMENTS:
             try:
                 vals = [int(x) for x in args.delete[0].split('-')]
                 if len(vals) == 2:
-                    bdb.delete_rec(0, vals[0], vals[1], True)
+                    bdb.delete_rec(0, vals[0], vals[1], is_range=True, retain_order=args.retain_order)
             except ValueError:
                 LOGERR('Invalid index or range to delete')
                 bdb.close_quit(1)
         else:
-            ids = []
-            # Select the unique indices
-            for idx in args.delete:
-                if idx not in ids:
-                    ids += (idx,)
-
+            ids = set(args.delete)
             try:
                 # Index delete order - highest to lowest
-                ids.sort(key=lambda x: int(x), reverse=True)
+                ids = sorted(map(int, ids), reverse=True)
                 for idx in ids:
-                    bdb.delete_rec(int(idx))
+                    bdb.delete_rec(idx, retain_order=args.retain_order)
             except ValueError:
                 LOGERR('Invalid index or range or combination')
                 bdb.close_quit(1)

--- a/buku.1
+++ b/buku.1
@@ -122,6 +122,9 @@ should be passed. In this case the environment variable EDITOR must be set. The 
 .BI \-d " " \--delete " [...]"
 Delete bookmarks. Accepts space-separated list of indices (e.g. 5 6 23 4 110 45) or a single hyphenated range (e.g. 100-200). Note that range and list don't work together. Deletes search results when combined with search options, if no arguments.
 .TP
+.BI \--retain-order
+When deleting bookmarks, shift indices of multiple records instead of replacing the deleted record with the last one.
+.TP
 .BI \-v " " \--version
 Show program version and exit.
 .TP

--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -170,7 +170,7 @@ class ApiBookmarkView(MethodView):
                 result_flag = bukudb.cleardb()
         else:
             bukudb = getattr(flask.g, 'bukudb', get_bukudb())
-            result_flag = bukudb.delete_rec(rec_id)
+            result_flag = bukudb.delete_rec(rec_id, retain_order=True)
         return Response.from_flag(result_flag)
 
 
@@ -220,7 +220,7 @@ class ApiBookmarkRangeView(MethodView):
         if starting_id > ending_id or ending_id > max_id:
             return Response.RANGE_NOT_VALID()
         idx = min([starting_id, ending_id])
-        result_flag = bukudb.delete_rec(idx, starting_id, ending_id, is_range=True)
+        result_flag = bukudb.delete_rec(idx, starting_id, ending_id, is_range=True, retain_order=True)
         return Response.from_flag(result_flag)
 
 
@@ -267,7 +267,7 @@ class ApiBookmarkSearchView(MethodView):
         bukudb = getattr(flask.g, 'bukudb', get_bukudb())
         res = None
         for bookmark in bukudb.searchdb(keywords, all_keywords, deep, regex):
-            if not bukudb.delete_rec(bookmark.id):
+            if not bukudb.delete_rec(bookmark.id, retain_order=True):
                 res = Response.FAILURE()
         return res or Response.SUCCESS()
 

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -241,7 +241,7 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
     def delete_model(self, model):
         try:
             self.on_model_delete(model)
-            res = self.bukudb.delete_rec(model.id)
+            res = self.bukudb.delete_rec(model.id, retain_order=True)
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 msg = _('Failed to delete record.')


### PR DESCRIPTION
* implementing a `retained_order` parameter for deletion-related operations (when truthy, `compactdb()` updates multiple record indices at once in a way that prevents their reordering)
* adding a `--retained-order` CLI option to allow for using said functionality from CLI  
  (...there doesn't seem to be any deletion support in the interactive shell :thinking:)
* changing Bukuserver to use this functionality by default
* fixing a bug in `delete_resultset()`
* ensuring that DB file is resized when committing (batch) deletions
* additionally, fixing text wrapping during record printing (for proper output of multiline descriptions, and to allow for linebreaks _between_ tags instead of hyphens)

@jarun honestly, I'd say it would make sense to _always_ retain ordering in CLI deletions as well, since this at least guarantees consistent bookmarks order (and IDs are not consistent either way). …Alternatively we could drop the "old" DB compression logic altogether; though the new one _is_ slower when deleting a large arbitrary resultset. (Then again, it's not like such updates need to be done very often.)

### Screenshots

<details><summary><strong>printing records with multiline data</strong></summary>

(in case of tags, we're tricking `textwrap` into inserting linebreaks after _commas_ rather than _hyphens_)
![sample data](https://github.com/user-attachments/assets/74efbc35-350f-4d9c-bd53-037ebad55218)
(an example of multiline description which looks better when rendered as such)
![usecase](https://github.com/user-attachments/assets/2f0c7610-1779-4564-8f7e-2676b80ee3d8)
</details>
<details><summary><strong>batch deletion of search results (with retained order of remaining records) + resized DB file</strong></summary>

```sh
# deleting all https:// bookmarks from generated.db
yes | buku --nostdin --db generated.db --markers :https:// --delete --retain-order
```
(tail output after removing 9987 records)
![deletion log](https://github.com/user-attachments/assets/4ddd691f-2d12-4697-be86-18150af24204)
(remaining records still retain their original order)
![remaining records](https://github.com/user-attachments/assets/bede6aae-1cca-4f72-9d3c-8af56d2f6771)
(the file size got reduced compared to the original database)
![file size](https://github.com/user-attachments/assets/e0eee202-8673-4a71-a770-1a0a4cea49cc)
</details>
<details><summary><strong>batch deletion of random records (with retained order)</strong></summary>

```sh
# deleting a bunch of randomly picked bookmarks from generated.db
yes | buku --nostdin --db generated.db --np --markers :: --random 9995 --delete --retain-order
```
(tail output after removing 9995 records)
![deletion log](https://github.com/user-attachments/assets/4f1b8c28-dae9-4f44-878f-5795b936e7cf)
(remaining records still retain their original order)
![remaining records](https://github.com/user-attachments/assets/ca2585e3-7033-43d6-bd4c-a1e404fa8d28)
</details>
<details><summary><strong>batch deletion of an index range (with retained order)</strong></summary>

```sh
yes | buku --nostdin --db generated.db --np --delete 3-9997 --retain-order
```
(tail output after removing 9995 sequential records)
![deletion log](https://github.com/user-attachments/assets/988442a2-382f-45cc-8e99-fcbdc3741d92)
(remaining records still retain their original order)
![remaining records](https://github.com/user-attachments/assets/6291ee79-fac9-4f73-8515-6f8c0827a566)
</details>
<details><summary><strong>batch deletion of an index range <em>without</em> retained order</strong></summary>

(removed indices are replaced in a single DB update)
![deletion log](https://github.com/user-attachments/assets/af26de94-d42a-4756-8b3b-914ad0049bb2)
(the last 10 records of resulting database)
![resulting database](https://github.com/user-attachments/assets/90c43154-bbcb-47df-829a-0d233de73eea)
(this also works when there's not enough records with larger indices to replace all that got removed)
![deletion log 2](https://github.com/user-attachments/assets/53fb7344-a790-4608-973e-6ec67b9bccb3)
(the last 4 records of resulting database)
![resulting database 2](https://github.com/user-attachments/assets/319f9eee-020a-4967-914f-662cb5cbdc85)
</details>
<details><summary><strong>webUI</strong></summary>

(GUI deletion uses retained order now since it's a more convenient and intuitively expected UX)
![image](https://github.com/user-attachments/assets/d1524313-dbfa-4a69-958f-00860b33bdea)
![image](https://github.com/user-attachments/assets/f66e191a-17a7-4ed8-bfb0-cb2649caa384)
![image](https://github.com/user-attachments/assets/e8b8a3a9-2751-487e-8d17-2314172bb6d9)
</details>
