### PR TITLE
[Bukuserver] DB name display

### DIFF
--- a/buku
+++ b/buku
@@ -618,6 +618,14 @@ class BukuDb:
 
         return (conn, cur)
 
+    @property
+    def dbfile(self) -> str:
+        return next(path for _, name, path in self.conn.execute('PRAGMA database_list') if name == 'main')
+
+    @property
+    def dbname(self) -> str:
+        return os.path.splitext(os.path.basename(self.dbfile))[0]
+
     def _fetch(self, query: str, *args, lock: bool = True) -> List[BookmarkVar]:
         if not lock:
             self.cur.execute(query, args)

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -120,7 +120,7 @@ def create_app(db_file=None):
         return {'app': app, 'bukudb': bukudb}
 
     app.jinja_env.filters.update(util.JINJA_FILTERS)
-    app.jinja_env.globals.update(_p=_p)
+    app.jinja_env.globals.update(_p=_p, dbfile=bukudb.dbfile, dbname=bukudb.dbname)
 
     admin = Admin(
         app, name='buku server', template_mode='bootstrap3',

--- a/bukuserver/templates/bukuserver/bookmark_create.html
+++ b/bukuserver/templates/bukuserver/bookmark_create.html
@@ -5,6 +5,7 @@
   {{ super() }}
   {{ buku.set_lang() }}
   {{ buku.limit_navigation_if_popup() }}
+  {{ buku.brand_dbname() }}
   {{ buku.script('bookmark.js') }}
   {{ buku.fetch_checkbox(form.fetch.data) }}
   {{ buku.focus() }}

--- a/bukuserver/templates/bukuserver/bookmark_details.html
+++ b/bukuserver/templates/bukuserver/bookmark_details.html
@@ -5,6 +5,7 @@
   {{ super() }}
   {{ buku.set_lang() }}
   {{ buku.limit_navigation_if_popup() }}
+  {{ buku.brand_dbname() }}
   {{ buku.details_formatting('.table.searchable') }}
   <script>$('#fa_filter, .table.searchable a').attr('tabindex', 1)</script>
   {{ buku.link_saved() }}

--- a/bukuserver/templates/bukuserver/bookmark_edit.html
+++ b/bukuserver/templates/bukuserver/bookmark_edit.html
@@ -3,6 +3,7 @@
 
 {% block head %}
   {{ super() }}
+  {{ buku.brand_dbname() }}
 {% endblock %}
 
 {% block edit_form %}

--- a/bukuserver/templates/bukuserver/bookmarks_list.html
+++ b/bukuserver/templates/bukuserver/bookmarks_list.html
@@ -4,6 +4,7 @@
 {% block head %}
   {{ super() }}
   {{ buku.close_if_popup() }}
+  {{ buku.brand_dbname() }}
   <script>
     function promptSwap(input, rowId, maxId={{count|tojson}}) {
       let _id = input.value = prompt({{ _('Swap record #{} with record #')|tojson }}.replace('{}', rowId), rowId) || "";

--- a/bukuserver/templates/bukuserver/home.html
+++ b/bukuserver/templates/bukuserver/home.html
@@ -4,6 +4,7 @@
 {% block head %}
   {{ super() }}
   {{ buku.close_if_popup() }}
+  {{ buku.brand_dbname() }}
   {{ buku.focus('main form[action="/"]') }}
 {% endblock %}
 

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -23,6 +23,27 @@
   <script>opener && (opener !== window) && document.body.classList.add('popup')</script>
 {% endmacro %}
 
+{% macro brand_dbname(nohover=False) %}
+  <style>
+    .dbname {font-weight: bold;  font-family: monospace;  cursor: help}
+    .navbar-brand .dbname {font-size: smaller}
+    body:not(.popup) .navbar-brand {text-align: center}
+    body.popup .navbar-brand .dbname, body:not(.popup) .popup.dbname {display: none}
+    .popup.dbname {float: right;  padding: 15px 20px}
+    {% if nohover %}
+    body:not(.popup) .navbar-brand {padding: 5px 15px}
+    {% else %}
+    body:not(.popup) .navbar-brand:hover {padding: 5px 15px}
+    body:not(.popup) .navbar-brand:not(:hover) .dbname {display: none}
+    {% endif %}
+  </style>
+  <script>{
+    let _dbname = (cls='') => `<div class="dbname ${cls}" title="${ {{dbfile|tojson}} }">${ {{dbname|tojson}} }</div>`;
+    addEventListener('load', () => {$('.navbar-brand').html((_, s) => s + _dbname());
+                                    $('nav.navbar').html((_, s) => s + _dbname('popup'))});
+  }</script>
+{% endmacro %}
+
 {% macro focus(location='body') %}
   {% if location %}
   <script>setTimeout(() => $('{{location|safe}} input:not([type=hidden])')[0]?.focus(), 500)</script>

--- a/bukuserver/templates/bukuserver/tag_edit.html
+++ b/bukuserver/templates/bukuserver/tag_edit.html
@@ -4,5 +4,6 @@
 {% block tail %}
   {{ super() }}
   {{ buku.set_lang() }}
+  {{ buku.brand_dbname() }}
   {{ buku.focus() }}
 {% endblock %}

--- a/bukuserver/templates/bukuserver/tags_list.html
+++ b/bukuserver/templates/bukuserver/tags_list.html
@@ -4,6 +4,7 @@
 {% block head %}
   {{ super() }}
   {{ buku.close_if_popup() }}
+  {{ buku.brand_dbname() }}
 {% endblock %}
 
 {% block model_menu_bar_before_filters %}


### PR DESCRIPTION
After adding [the ability to select/switch DB easily when using Bukuserver](https://github.com/jarun/buku/wiki/Bukuserver-(WebUI)#runner-script), it became possible for the user to forget which DB is being used at the moment. Because of that, I've added a few improvements:

* implementing `.dbfile` & `.dbname` properties in `BukuDb`
* allowing to check DB name in Bukuserver by hovering the `.navbar-brand` element
* displaying DB name clearly in popup windows
* displaying full DB path in tooltip when hovering the DB name (the cursor is set to `help` to indicate existence of the tooltip)

### Screenshots

(unhovered logo)
![unhovered](https://github.com/user-attachments/assets/4d2e50c5-9503-44f9-a3dc-313d72c52d26)
(hovered logo)
![hovered](https://github.com/user-attachments/assets/ddaa2345-27a5-4f4b-b25b-6b2220377f3d)
(in a popup window)
![popup](https://github.com/user-attachments/assets/df2f73fa-8fe8-4696-bf5d-b87ce387e4e7)
