### PR TITLE
Fixing popup detection for sites that prevent exposing opener

### DIFF
--- a/bukuserver/api.py
+++ b/bukuserver/api.py
@@ -282,6 +282,6 @@ class BookmarkletView(MethodView):  # pylint: disable=too-few-public-methods
 
         bukudb = getattr(flask.g, 'bukudb', get_bukudb())
         rec_id = bukudb.get_rec_id(url)
-        if rec_id:
-            return redirect(url_for('bookmark.edit_view', id=rec_id))
-        return redirect(url_for('bookmark.create_view', link=url, title=title, description=description, tags=tags, fetch=fetch))
+        goto = (url_for('bookmark.edit_view', id=rec_id, popup=True) if rec_id else
+                url_for('bookmark.create_view', link=url, title=title, description=description, tags=tags, fetch=fetch, popup=True))
+        return redirect(goto)

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro close_if_popup() %}
-  <script>opener && (opener !== window) && close()</script>
+  <script>({{ g.popup|default|tojson }} || (opener && (opener !== window))) && close()</script>
 {% endmacro %}
 
 {% macro limit_navigation_if_popup() %}
@@ -20,7 +20,14 @@
     .popup :is(#admin-navbar-collapse, .navbar-toggle) {display: none !important}
     .popup .nav-tabs :is(:first-child, :nth-child(2):not(.active)) > * {display: none}
   </style>
-  <script>opener && (opener !== window) && document.body.classList.add('popup')</script>
+  <script>
+    const POPUP = {{ g.popup|default|tojson }} || (opener && (opener !== window)) || '';
+    POPUP && (document.body.classList.add('popup'), setTimeout(() => {
+      $(`.nav-tabs a:not([href^='javascript:'])`).each((_, e) => e.href += `&popup=${POPUP}`);
+      $(`.submit-row .btn-danger`).on('click', () => close());
+      $(`.delete-form`).prepend(`<input type="hidden" name="popup" value="${POPUP}">`);
+    }));
+  </script>
 {% endmacro %}
 
 {% macro brand_dbname(nohover=False) %}
@@ -75,7 +82,7 @@
     const SUCCESS = [{{ _gettext('Record was successfully created.') | tojson }},
                      {{ _gettext('Record was successfully saved.') | tojson }}];
     $(`.alert-success`).filter((idx, e) => SUCCESS.some(s => e.innerText.includes(s))).html((_, s) =>
-      s.replace(/(<\/button>)([^]*)$/, `$1<a href="{{ url_for('.details_view', id=saved, url=backlink) }}">$2</a>`));
+      s.replace(/(<\/button>)([^]*)$/, `$1<a href="{{ url_for('.details_view', id=saved, url=backlink, popup=g.popup) }}">$2</a>`));
   }</script>
   {% endif %}
 {% endmacro %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -146,8 +146,8 @@ def assert_bookmark(bookmark, query, tags=None):
 @pytest.mark.gui
 @pytest.mark.slow
 @pytest.mark.parametrize('exists, uri, tab, args', [
-    (False, '/bookmark/new/', 'Create', ['link', 'title', 'description']),
-    (True, '/bookmark/edit/', 'Edit', ['id']),
+    (False, '/bookmark/new/', 'Create', ['link', 'title', 'description', 'popup']),
+    (True, '/bookmark/edit/', 'Edit', ['id', 'popup']),
 ])
 def test_bookmarklet_view(bukudb, client, exists, uri, tab, args):
     query = {'url': 'http://example.com', 'title': 'Sample site', 'description': 'Foo bar baz'}


### PR DESCRIPTION
fixes #825

Since `opener` is not available when the popup is opened from a page fetched with `Cross-Origin-Opener-Policy: same-origin` response header (and there's no other reliable frontend-side way of detecting that the page was loaded in a popup), I've ended up implementing an extra request parameter: `popup=True`.

It's added to URLs that the bookmarklet handler redirects to, used to determine if the current page is a popup, and is persistently retained by (internal) requests from bookmark forms (which are supposed to be the only pages accessible from within the bookmarklet popup).

The following pages were tested:
* opening the popup for a new bookmark
* opening the popup for an existing bookmark
* switching between edit/details tabs for an existing bookmark (the window is still detected as a popup after the new page is rendered)
* manual refresh (the window is still detected as a popup after the form is reloaded)
* Cancel button (the popup is closed immediately)
* Save button (the popup is closed after completing the request)
* Delete button (the popup is closed after completing the change)
* Save and Continue Editing button (the window is still detected as a popup after the form is reloaded)
* Save and Add Another button (the window is still detected as a popup after the form is reloaded)
* "Record was successfully saved" link (the window is still detected as a popup after the form is reloaded)
* various combinations of the above actions

<details><summary><h3>Screenshots</h3></summary>

![new bookmark](https://github.com/user-attachments/assets/ec8012c2-af4a-4243-86b6-1dc4af7bd9f5 "new bookmark")
![save-and-continue-editing](https://github.com/user-attachments/assets/5da5fcff-ac9f-407f-b704-446510b674c3 "save-and-continue-editing")
![save-and-add-another](https://github.com/user-attachments/assets/ceb51384-7853-4680-9187-6e6225163097 "save-and-add-another")
![navigating the backlink](https://github.com/user-attachments/assets/572d9ca2-7d77-483c-9ac8-d11a490e6fe4 "navigating the backlink")
</details>