### PR TITLE
Fixing rendering no-netloc URLs in non-full modes

### DIFF
--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -127,10 +127,9 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
         url_for_index_view_netloc = None
         if netloc:
             url_for_index_view_netloc = get_index_view_url(flt0_url_netloc_match=netloc)
-        if netloc and parsed_url.scheme:
-            res += [f'<span class="title">{link(title, model.url, new_tab=new_tab)}</span>']
-        else:
-            res += [f'<span class="title">{escape(title)}</span>']
+        _title = (escape(title) if self.url_render_mode == 'full' and (not netloc or not parsed_url.scheme) else
+                  link(title, model.url, new_tab=new_tab))
+        res += [f'<span class="title" title="{model.url}">{_title}</span>']
         if self.url_render_mode == 'netloc' and url_for_index_view_netloc:
             res += [f'<span class="netloc"> ({link(netloc, url_for_index_view_netloc)})</span>']
         if not parsed_url.scheme:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -302,7 +302,19 @@ def test_env_per_page(bukudb, app, client, total, per_page, pages, last_page):
 @pytest.mark.parametrize('favicons', [False, True, None])
 @pytest.mark.parametrize('mode', ['full', 'netloc', 'netloc-tag', None])
 def test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab):
-    url, netloc, title, desc, tags = 'http://example.com', 'example.com', 'Sample site', 'Foo bar baz', ',bar,baz,foo,'
+    _test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab, 'http://example.com', 'example.com', 'Sample site')
+
+@pytest.mark.parametrize('url, netloc, title', [
+    ('http://example.com', 'example.com', ''),
+    ('javascript:void(0)', '', 'Sample site'),
+    ('javascript:void(0)', '', ''),
+])
+@pytest.mark.parametrize('mode', ['full', 'netloc', 'netloc-tag'])
+def test_env_entry_render_params_blanks(bukudb, app, client, mode, url, netloc, title):
+    _test_env_entry_render_params(bukudb, app, client, mode, True, True, url, netloc, title)
+
+def _test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab, url, netloc, title):
+    desc, tags = 'Foo bar baz', ',bar,baz,foo,'
     _add_rec(bukudb, url, title, tags, desc)
     _tags = tags.strip(',').split(',')
     if mode:
@@ -315,14 +327,17 @@ def test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab):
     dom = assert_response(client.get('/bookmark/'), '/bookmark/')
     cell = ' '.join(etree.tostring(dom.xpath(f'//td{xpath_cls("col-entry")}')[0], encoding='unicode').strip().split())
     target = '' if not new_tab else ' target="_blank"'
-    icon = '' if not favicons else f'<img class="favicon" src="http://www.google.com/s2/favicons?domain={netloc}"/> '
-    prefix = f'<td class="col-entry"> {icon}<span class="title"><a href="{url}"{target}>{title}</a></span>'
+    icon = '' if not favicons else (netloc and f'<img class="favicon" src="http://www.google.com/s2/favicons?domain={netloc}"/> ')
+    urltext = title or '&lt;EMPTY TITLE&gt;'
+    _title = (urltext if not netloc else f'<a href="{url}"{target}>{urltext}</a>')
+    prefix = f'<td class="col-entry"> {icon}<span class="title">{_title}</span>'
     tags = [f'<a class="btn label label-default" href="/bookmark/?flt0_tags_contain={s}">{s}</a>' for s in _tags]
-    netloc_tag = ('' if mode == 'netloc' else
+    netloc_tag = ('' if mode == 'netloc' or not netloc else
                   f'<a class="btn label label-success" href="/bookmark/?flt0_url_netloc_match={netloc}">netloc:{netloc}</a>')
     suffix = f'<div class="tag-list">{netloc_tag}{"".join(tags)}</div><div class="description">{desc}</div> </td>'
     if mode == 'netloc':
-        assert cell == f'{prefix}<span class="netloc"> (<a href="/bookmark/?flt0_url_netloc_match={netloc}">{netloc}</a>)</span>{suffix}'
+        _netloc = netloc and f'<span class="netloc"> (<a href="/bookmark/?flt0_url_netloc_match={netloc}">{netloc}</a>)</span>'
+        assert cell == prefix + _netloc + suffix
     elif mode == 'netloc-tag':
         assert cell == prefix + suffix
     else:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -329,8 +329,8 @@ def _test_env_entry_render_params(bukudb, app, client, mode, favicons, new_tab, 
     target = '' if not new_tab else ' target="_blank"'
     icon = '' if not favicons else (netloc and f'<img class="favicon" src="http://www.google.com/s2/favicons?domain={netloc}"/> ')
     urltext = title or '&lt;EMPTY TITLE&gt;'
-    _title = (urltext if not netloc else f'<a href="{url}"{target}>{urltext}</a>')
-    prefix = f'<td class="col-entry"> {icon}<span class="title">{_title}</span>'
+    _title = (urltext if not netloc and mode in ('full', None) else f'<a href="{url}"{target}>{urltext}</a>')
+    prefix = f'<td class="col-entry"> {icon}<span class="title" title="{url}">{_title}</span>'
     tags = [f'<a class="btn label label-default" href="/bookmark/?flt0_tags_contain={s}">{s}</a>' for s in _tags]
     netloc_tag = ('' if mode == 'netloc' or not netloc else
                   f'<a class="btn label label-success" href="/bookmark/?flt0_url_netloc_match={netloc}">netloc:{netloc}</a>')


### PR DESCRIPTION
fixes #828

Since the issue is _not_ exclusive to URLs without titles, I abandoned my original idea of replacing "&lt;EMPTY TITLE&gt;" with the URL text, and instead simply changed rendering logic so that the title link only gets disabled in `full` mode (…where it's not really needed in the first place, since the same hyperlink with URL text is rendered immediately below it). I've also added a tooltip with the URL to the title, so that before the user clicks on a link he'll have a chance to check it first.

### Screenshots

<details><summary><code>BUKUSERVER_URL_RENDER_MODE=full</code></summary>

(before)
![before](https://github.com/user-attachments/assets/084c7358-57c4-494d-8b51-3f651f70f587 "before")
(after)
![after](https://github.com/user-attachments/assets/e54d0016-d0bb-4cfe-b308-1da0bb3e22e3 "after")
</details>

<details><summary><code>BUKUSERVER_URL_RENDER_MODE=netloc-tag</code></summary>

(before)
![before](https://github.com/user-attachments/assets/7797403d-271d-4d0b-9ab3-b59bd298c126 "before")
(after)
![after](https://github.com/user-attachments/assets/1b29ba1c-89bc-41d9-b6db-c18246a00b17 "after")
</details>

<details><summary><code>BUKUSERVER_URL_RENDER_MODE=netloc</code></summary>

(before)
![before](https://github.com/user-attachments/assets/6103f9c7-98f7-4321-bf49-640ef42dc4de "before")
(after)
![after](https://github.com/user-attachments/assets/e767808a-3050-4026-8ffc-e24c26302a19 "after")
</details>
