### PR TITLE
[Bukuserver] support for specifying DB name

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -1,5 +1,7 @@
 ## Bukuserver
 
+_**Note: see [the runner script](https://github.com/jarun/buku/wiki/Bukuserver-%28WebUI%29#runner-script) for advanced installation/running/DB swapping functionality**_
+
 ### Table of Contents
 
 - [Installation](#installation)
@@ -127,6 +129,8 @@ Note: `BUKUSERVER_` is the common prefix (_every variable starts with it_).
 Note: Valid boolean values are `true`, `false`, `1`, `0` (case-insensitive).
 
 Note: if input is invalid, the default value will be used if defined
+
+Note: `BUKUSERVER_DB_FILE` can be a DB name (plain filename without extension; cannot contain `.`). The specified DB with `.db` extension is located in default DB directory (which you can override with `BUKU_DEFAULT_DBDIR`).
 
 Note: `BUKUSERVER_LOCALE` requires either `flask_babel` or `flask_babelex` installed
 

--- a/bukuserver/server.py
+++ b/bukuserver/server.py
@@ -102,6 +102,9 @@ def after_request(response):
 def create_app(db_file=None):
     """create app."""
     app = Flask(__name__)
+    db_file = os.getenv('BUKUSERVER_DB_FILE') or db_file
+    if db_file and not os.path.dirname(db_file) and not os.path.splitext(db_file)[1]:
+        db_file = os.path.join(BukuDb.get_default_dbdir(), db_file + '.db')
     os.environ.setdefault('FLASK_DEBUG', ('1' if get_bool_from_env_var('BUKUSERVER_DEBUG') else '0'))
     per_page = int(os.getenv('BUKUSERVER_PER_PAGE', str(views.DEFAULT_PER_PAGE)))
     per_page = per_page if per_page > 0 else views.DEFAULT_PER_PAGE
@@ -117,7 +120,7 @@ def create_app(db_file=None):
         get_bool_from_env_var('BUKUSERVER_DISABLE_FAVICON', True)
     app.config['BUKUSERVER_OPEN_IN_NEW_TAB'] = \
         get_bool_from_env_var('BUKUSERVER_OPEN_IN_NEW_TAB')
-    app.config['BUKUSERVER_DB_FILE'] = os.getenv('BUKUSERVER_DB_FILE') or db_file
+    app.config['BUKUSERVER_DB_FILE'] = db_file
     reverse_proxy_path = os.getenv('BUKUSERVER_REVERSE_PROXY_PATH')
     if reverse_proxy_path:
         if not reverse_proxy_path.startswith('/'):
@@ -126,7 +129,7 @@ def create_app(db_file=None):
             print('Warning: reverse proxy path should not include trailing slash')
         app.config['REVERSE_PROXY_PATH'] = reverse_proxy_path
         ReverseProxyPrefixFix(app)
-    bukudb = BukuDb(dbfile=app.config['BUKUSERVER_DB_FILE'])
+    bukudb = BukuDb(dbfile=db_file)
     app.config['FLASK_ADMIN_SWATCH'] = (os.getenv('BUKUSERVER_THEME') or 'default').lower()
     app.config['BUKUSERVER_LOCALE'] = os.getenv('BUKUSERVER_LOCALE') or 'en'
     app.app_context().push()


### PR DESCRIPTION
Nothing fancy here, just duplicating for Bukuserver the logic added to `--db` in #824

This can be useful when invoking Bukuserver manually (…which I only do for dev purposes, but it's more likely to be useful for regular users :sweat_smile:)

…Also added a link to the Wiki in Bukuserver readme (so that the users interested in Bukuserver have a better chance of finding out there's a runner to begin with)