### PR TITLE
incorrect expression in to_temp_file_content()

### DIFF
--- a/buku
+++ b/buku
@@ -5481,7 +5481,7 @@ def to_temp_file_content(url, title_in, tags_in, desc):
 
     # TAGS
     strings += ('# Add comma-separated TAGS in next line (single line).',)
-    strings += (tags_in.strip(DELIM),) if not None else ''
+    strings += [(tags_in or '').strip(DELIM)]
 
     # DESC
     strings += ('# Add COMMENTS in next line(s). Leave blank to web fetch, "-" for no comments.',)

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -427,10 +427,6 @@ def test_to_temp_file_content(url, title_in, tags_in, desc):
         title_text = "-"
     else:
         title_text = title_in
-    if tags_in is None:
-        with pytest.raises(AttributeError):
-            res = buku.to_temp_file_content(url, title_in, tags_in, desc)
-        return
     res = buku.to_temp_file_content(url, title_in, tags_in, desc)
     lines = """# Lines beginning with "#" will be stripped.
 # Add URL in next line (single line).{}


### PR DESCRIPTION
fixes #837:
* `if not None` condition (_always_ evaluates to `False`)
* concatenating a list with a string (would result in `TypeError`)

…Seriously, how was this bug never discovered for 8 years of its existence?! 🫠