### PR TITLE
Fix crash when adding new bookmark with the `--suggest` option without providing any tags

### DIFF
--- a/buku
+++ b/buku
@@ -2330,7 +2330,7 @@ class BukuDb:
             DELIM separated string of tags.
         """
 
-        tags = tagstr.split(',')
+        tags = (tagstr or '').split(',')
         if not len(tags):
             return tagstr
 


### PR DESCRIPTION
`buku --suggest -a [URL]` causes a crash in the `suggest_similar_tag` function due to calling `split()` on a `NoneType`

Basically the same issue as #837.
