### PR TITLE
Handling the value passed into prompt() by --stag

### DIFF
--- a/buku
+++ b/buku
@@ -4652,7 +4652,7 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
 
     if noninteractive:
         try:
-            for i, row in enumerate(results):
+            for i, row in enumerate(results or []):
                 print_single_rec(row, i + 1, columns)
         except Exception as e:
             LOGERR(e)


### PR DESCRIPTION
fixes #839:
* adding support for [the `results` value explicitly passed into `prompt()` by `--stag` option handler](https://github.com/jarun/buku/blob/v5.0/buku#L6332)

### Screenshots

(before)
![before](https://github.com/user-attachments/assets/9e6056ce-2163-46f7-a50f-aa09f310355a)
(after)
![after](https://github.com/user-attachments/assets/b0dad697-0c7d-4b44-b053-c80b8285cae8)
