### PR TITLE
auto-import from Brave Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get started right away, jump to the [Quickstart](#quickstart) section. `buku`
 ### Features
 
 - Store bookmarks with auto-fetched title, tags and description
-- Auto-import from Firefox, Google Chrome, Chromium and MS Edge
+- Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge
 - Open bookmarks and search results in browser
 - Browse cached page from the Wayback Machine
 - Text editor integration
@@ -225,7 +225,9 @@ ENCRYPTION OPTIONS:
 
 POWER TOYS:
       --ai                 auto-import bookmarks from web browsers
-                           Firefox, Chrome, Chromium, Vivaldi, Edge
+                           Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
+                           (Firefox profile can be specified using
+                           environment variable FIREFOX_PROFILE)
       -e, --export file    export bookmarks to Firefox format HTML
                            export XBEL, if file ends with '.xbel'
                            export Markdown, if file ends with '.md'

--- a/buku
+++ b/buku
@@ -2891,7 +2891,7 @@ class BukuDb:
     def auto_import_from_browser(self, firefox_profile=None):
         """Import bookmarks from a browser default database file.
 
-        Supports Firefox, Google Chrome, Vivaldi, and Microsoft Edge.
+        Supports Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge.
 
         Returns
         -------
@@ -2903,18 +2903,21 @@ class BukuDb:
             gc_bm_db_path = '~/.config/google-chrome/Default/Bookmarks'
             cb_bm_db_path = '~/.config/chromium/Default/Bookmarks'
             vi_bm_db_path = '~/.config/vivaldi/Default/Bookmarks'
+            br_bm_db_path = '~/.config/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/.config/microsoft-edge/Default/Bookmarks'
             default_ff_folder = '~/.mozilla/firefox'
         elif sys.platform == 'darwin':
             gc_bm_db_path = '~/Library/Application Support/Google/Chrome/Default/Bookmarks'
             cb_bm_db_path = '~/Library/Application Support/Chromium/Default/Bookmarks'
             vi_bm_db_path = '~/Library/Application Support/Vivaldi/Default/Bookmarks'
+            br_bm_db_path = '~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/Library/Application Support/Microsoft Edge/Default/Bookmarks'
             default_ff_folder = '~/Library/Application Support/Firefox'
         elif sys.platform == 'win32':
             gc_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Google/Chrome/User Data/Default/Bookmarks')
             cb_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Chromium/User Data/Default/Bookmarks')
             vi_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Vivaldi/User Data/Default/Bookmarks')
+            br_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/BraveSoftware/Brave-Browser/User Data/Default/Bookmarks')
             me_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Microsoft/Edge/User Data/Default/Bookmarks')
             default_ff_folder = os.path.expandvars('%APPDATA%/Mozilla/Firefox/')
         else:
@@ -2939,7 +2942,8 @@ class BukuDb:
         with self.lock:
             resp = 'y'
 
-            chrome_based = {'Google Chrome': gc_bm_db_path, 'Chromium': cb_bm_db_path, 'Vivaldi': vi_bm_db_path}
+            chrome_based = {'Google Chrome': gc_bm_db_path, 'Chromium': cb_bm_db_path, 'Vivaldi': vi_bm_db_path,
+                            'Brave': br_bm_db_path}
             for name, path in chrome_based.items():
                 try:
                     if os.path.isfile(os.path.expanduser(path)):
@@ -5987,7 +5991,7 @@ POSITIONAL ARGUMENTS:
     power_grp = argparser.add_argument_group(
         title='POWER TOYS',
         description='''    --ai                 auto-import bookmarks from web browsers
-                         Firefox, Chrome, Chromium, Vivaldi, Edge
+                         Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
                          (Firefox profile can be specified using
                          environment variable FIREFOX_PROFILE)
     -e, --export file    export bookmarks to Firefox format HTML

--- a/buku.1
+++ b/buku.1
@@ -10,7 +10,7 @@ is a command-line utility to store, tag, search and organize bookmarks.
 .B Features
 .PP
   * Store bookmarks with auto-fetched title, tags and description
-  * Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, and MS Edge
+  * Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge
   * Open bookmarks and search results in browser
   * Browse cached page from the Wayback Machine
   * Text editor integration
@@ -222,7 +222,7 @@ Decrypt (unlock) the DB file with
 .SH POWER OPTIONS
 .TP
 .BI \--ai
-Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, and Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE.)
+Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE.)
 .TP
 .BI \-e " " \--export " file"
 Export bookmarks to Firefox bookmarks formatted HTML. Works with all search options.


### PR DESCRIPTION
resolves #748:
* adding paths for Brave Browser bookmarks file to `auto_import_from_browser()`

Note: tested only on Linux; other paths are based on information obtained via an internet search.

### Screenshot

![CLI auto-import](https://github.com/user-attachments/assets/897b168d-6b97-49c8-ae93-4a9d4e88e013)
