### PR TITLE
import formats clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ POWER TOYS:
                            combines with search results, if opted
       -i, --import file    import bookmarks from file
                            supports .html .xbel .json .md .org .rss .atom .db
+                           (.json = Firefox backup; .db = another Buku DB)
       -p, --print [...]    show record details by indices, ranges
                            print all bookmarks, if no arguments
                            -n shows the last n results (like tail)

--- a/buku
+++ b/buku
@@ -6001,6 +6001,7 @@ POSITIONAL ARGUMENTS:
                          combines with search results, if opted
     -i, --import file    import bookmarks from file
                          supports .html .xbel .json .md .org .rss .atom .db
+                         (.json = Firefox backup; .db = another Buku DB)
     -p, --print [...]    show record details by indices, ranges
                          print all bookmarks, if no arguments
                          -n shows the last n results (like tail)


### PR DESCRIPTION
resolves #787:
* adding a brief clarification for `.json`/`.db` extensions to the `--import` help text (based on [information from the manpage](https://github.com/jarun/buku/blob/v5.0/buku.1#L250-L253))