### PR TITLE
amd64 docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     environment:
       IMAGE_NAME: bukuserver/bukuserver
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:current
 
 test-template: &test-template
   working_directory: ~/Buku
@@ -89,36 +89,23 @@ jobs:
 #            go get github.com/tcnksm/ghr
 #            ghr -t ${GITHUB_API_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${CIRCLE_TAG} ./dist/
 
-  build-docker-image:
+  build-and-publish-docker-image:
     executor: docker-publisher
     steps:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build Docker image
-          command: docker build -t $IMAGE_NAME:latest .
+          name: Login to Docker Hub
+          command: 'echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin'
       - run:
-          name: Archive Docker image
-          command: docker save -o image.tar $IMAGE_NAME
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./image.tar
-
-  publish-on-docker-hub:
-    executor: docker-publisher
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker
+          name: Create a builder instance
+          command: docker buildx create --use
       - run:
-          name: Load archived Docker image
-          command: docker load -i /tmp/workspace/image.tar
-      - run:
-          name: Publish Docker Image to Docker Hub
+          name: Build Docker image and publish it to Docker Hub
           command: |
-            echo "${DOCKERHUB_PASS}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-            docker push ${IMAGE_NAME}:latest
+            TAGS="--tag $IMAGE_NAME:latest"
+            [ "$CIRCLE_TAG" ] && TAGS="--tag $IMAGE_NAME:$CIRCLE_TAG $TAGS"
+            docker buildx build --platform=linux/amd64,linux/arm64 $TAGS --push .
 
 workflows:
   version: 2.1
@@ -153,15 +140,7 @@ workflows:
 
   publish-docker-image:
     jobs:
-      - build-docker-image:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - publish-on-docker-hub:
-          requires:
-            - build-docker-image
+      - build-and-publish-docker-image:
           filters:
             tags:
               only: /^v.*/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ buku.py
 /tests/vcr_cassettes/tests.test_bukuDb/
 /bookmarks.db
 /venv/
+/docker-compose/data/*
+!/docker-compose/data/nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-MAINTAINER Ameya Shenoy "shenoy.ameya@gmail.com"
+LABEL org.opencontainers.image.authors="shenoy.ameya@gmail.com"
 
 ENV BUKUSERVER_PORT=5001
 
@@ -19,11 +19,11 @@ RUN set -ex \
     gunicorn \
     /buku[server] \
   && apk del .build-deps \
+  && echo "import sys;  bind = '0.0.0.0:${BUKUSERVER_PORT}'" > 'gunicorn.conf.py' \
   && rm -rf /buku
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z 127.0.0.1 ${BUKUSERVER_PORT} || exit 1
 
-ENTRYPOINT gunicorn --bind 0.0.0.0:${BUKUSERVER_PORT} "bukuserver.server:create_app()"
+ENTRYPOINT ["gunicorn", "bukuserver.server:create_app()"]
 EXPOSE ${BUKUSERVER_PORT}
-

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   bukuserver:
     image: bukuserver/bukuserver


### PR DESCRIPTION
resolves #786:
* the docker image built when a version tag gets pushed is now also built for `linux/arm64` platform (in addition to `linux/amd64`)

also:
* individual version tags now get pushed to the Docker repo (in addition to `:latest`)
* fixing various Docker-related warnings
* adding temporary Docker files (i.e. `bookmarks.db`) to `.gitignore`

_Note: I've only tested if the Docker image works on my machine; so technically I don't know for sure if it works on arm64_ :sweat_smile:

### Screenshots
(I used a private Docker repo for testing the build)
![docker repo](https://github.com/user-attachments/assets/7a7c32bc-164e-494d-b38d-285b084d60fb)
(web-app run by `docker compose up`)
![app running in docker](https://github.com/user-attachments/assets/9b2e2193-cab1-46a8-964c-68863516f183)
