### PR TITLE
fix ResourceWarning messages on Python 3.13

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict
 from http import HTTPStatus
 import pytest
@@ -45,7 +46,9 @@ def client(tmp_path):
     test_db = tmp_path / 'test.db'
     app = server.create_app(test_db.as_posix())
     client = app.test_client()
-    return client
+    yield client
+    flask.g.bukudb.close()
+    os.remove(test_db)
 
 
 def test_home(client):


### PR DESCRIPTION
After a recent update, `pytest` started producing warnings about unclosed DB connections during testing on Python 3.13:
![testing log](https://github.com/user-attachments/assets/08438978-03fc-4b5b-ad35-6e7e8bfff03d)