### PR TITLE
migrating to Flask-Admin v2

### DIFF
--- a/bukuserver/README.md
+++ b/bukuserver/README.md
@@ -36,6 +36,8 @@ $ # regular/venv install
 $ pip3 install "buku[server]"
 $ # pipx install
 $ pipx install "buku[server]"
+$ # with locales
+$ pipx install "buku[server,locales]"
 ```
 
 #### From source
@@ -45,6 +47,8 @@ $ git clone https://github.com/jarun/buku
 $ cd buku
 $ # regular/venv install
 $ pip3 install ".[server]"
+$ # with locales
+$ pip3 install ".[server,locales]"
 ```
 
 #### Using Docker
@@ -134,7 +138,7 @@ _**²**_ if input is invalid, the default value will be used if defined
 
 _**³**_ `BUKUSERVER_DB_FILE` can be a DB name (plain filename without extension; cannot contain `.`). The specified DB with `.db` extension is located in default DB directory (which you can override with `BUKU_DEFAULT_DBDIR`).
 
-_**⁴**_ `BUKUSERVER_LOCALE` requires either `flask_babel` or `flask_babelex` installed
+_**⁴**_ `BUKUSERVER_LOCALE` requires buku to be installed with `[locales]`
 
 _**⁵**_ the value for `BUKUSERVER_REVERSE_PROXY_PATH` is recommended to include preceding slash and not have trailing slash (i.e. use `/foo` not `/foo/`)
 

--- a/bukuserver/__init__.py
+++ b/bukuserver/__init__.py
@@ -1,8 +1,5 @@
-try:  # as per Flask-Admin-1.6.1
-    try:
-        from flask_babelex import gettext, ngettext, pgettext, lazy_gettext, lazy_pgettext, LazyString
-    except ImportError:
-        from flask_babel import gettext, ngettext, pgettext, lazy_gettext, lazy_pgettext, LazyString
+try:
+    from flask_babel import gettext, ngettext, pgettext, lazy_gettext, lazy_pgettext, LazyString
 except ImportError:
     from flask_admin.babel import gettext as _gettext, ngettext, lazy_gettext
     gettext = lambda s, *a, **kw: (s if not kw else _gettext(s, *a, **kw))

--- a/bukuserver/requirements.txt
+++ b/bukuserver/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.2.2
-Flask-Admin>=1.6.1,<2
+Flask-Admin>=2.0.0
 flask-paginate>=2022.1.8
 Flask-WTF>=1.0.1
 Flask>=2.2.2

--- a/bukuserver/templates/bukuserver/lib.html
+++ b/bukuserver/templates/bukuserver/lib.html
@@ -143,12 +143,11 @@
 {% macro page_size_custom() %}
   <script>
     $(document).ready(function() {
-      const SIZES = [20, 50, 100];  // hardcoded list; see page_size_form() in admin/model/layout.html
       let pageSize = url => new URL(url || location.host).searchParams.get('page_size');
       $(`.nav.nav-tabs .dropdown-menu`).each(function () {
         let _sizes = $(`a.dropdown-item`, this).map(function () {return pageSize(this.href)}).get();
-        if (SIZES.every((x, i) => x == _sizes[i]))
-          $('a', this).last().clone().text({{ _('custom')|tojson }}).attr('href', `#`).on('click', () => {
+        if (_sizes.length > 2 && _sizes.length == new Set(_sizes).size)  // 3+ links; each link has different pagesize
+          $('a', this).last().clone().text({{ _('custom')|tojson }}).removeClass('active').attr('href', `#`).on('click', () => {
             let page = prompt({{ _('Set custom page size (empty for default)')|tojson }}, pageSize(location) || '');
             if (Number(page) || (page == "")) {
               let search = new URL(location).searchParams;

--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -196,12 +196,19 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
         super().__init__(custom_model, *args, **kwargs)
 
     @property
+    def url_render_mode(self):
+        return app_param('URL_RENDER_MODE', DEFAULT_URL_RENDER_MODE)
+
+    @property
     def page_size(self):
         return app_param('PER_PAGE', DEFAULT_PER_PAGE)
 
     @property
-    def url_render_mode(self):
-        return app_param('URL_RENDER_MODE', DEFAULT_URL_RENDER_MODE)
+    def page_size_options(self):
+        return tuple(sorted(set([self.page_size] + list(super().page_size_options))))
+
+    def get_safe_page_size(self, page_size):  # un-enforcing the restriction
+        return (page_size if self.can_set_page_size and page_size > 0 else self.page_size)
 
     def create_form(self, obj=None):
         form = super().create_form(obj)
@@ -463,6 +470,13 @@ class TagModelView(BaseModelView, ApplyFiltersMixin):
     @property
     def page_size(self):
         return app_param('PER_PAGE', DEFAULT_PER_PAGE)
+
+    @property
+    def page_size_options(self):
+        return tuple(sorted(set([self.page_size] + list(super().page_size_options))))
+
+    def get_safe_page_size(self, page_size):  # un-enforcing the restriction
+        return (page_size if self.can_set_page_size and page_size > 0 else self.page_size)
 
     @expose('/refresh', methods=['POST'])
     def refresh(self):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ with open('buku.py', encoding='utf-8') as f:
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
+server_locales_require = ['Flask-Admin[translation]']
+
 tests_require = [
     'attrs>=17.4.0',
     'beautifulsoup4>=4.6.0',
@@ -32,13 +34,12 @@ tests_require = [
     'setuptools>=41.0.1',
     'vcrpy>=1.13.0',
     'lxml',
-    'flask_babel',
-]
+] + server_locales_require
 
 
 server_require = [
     "arrow>=1.2.2",
-    "Flask-Admin>=1.6.1,<2",
+    "Flask-Admin>=2.0.0",
     "flask-paginate>=2022.1.8",
     "Flask-WTF>=1.0.1",
     "Flask>=2.2.2",
@@ -77,6 +78,7 @@ setup(
     extras_require={
         "tests": tests_require + server_require,
         "server": server_require,
+        "locales": server_locales_require,
         "docs": [
             "myst-parser>=0.17.0",
             "sphinx-rtd-theme>=1.0.0",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -13,20 +13,12 @@ def setup_obj(monkeypatch):
 
     return setup
 
+_reqs = lambda path: [s for s in pathlib.Path(path).read_text(encoding='utf8', errors='surrogateescape').splitlines()
+                      if not s.startswith('#') and s != 'setuptools']
+
 
 def test_bukuserver_requirement(setup_obj):
-    assert [
-        x
-        for x in pathlib.Path("bukuserver/requirements.txt").read_text(encoding="utf8", errors="surrogateescape").splitlines()
-        if "flask-reverse-proxy-fix" not in x
-    ] == setup_obj.server_require
-
+    assert sorted(_reqs('bukuserver/requirements.txt')) == sorted(setup_obj.server_require)
 
 def test_buku_requirement(setup_obj):
-    assert sorted(
-        [
-            x
-            for x in pathlib.Path("requirements.txt").read_text(encoding="utf8", errors="surrogateescape").splitlines()
-            if not x.startswith('#') and x != 'setuptools'
-        ]
-    ) == sorted(setup_obj.install_requires)
+    assert sorted(_reqs('requirements.txt')) == sorted(setup_obj.install_requires)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -250,7 +250,7 @@ def test_update(bukudb, client, override):
 @pytest.mark.slow
 @pytest.mark.parametrize('redirect, uri, args', [
     ('_add_another', '/bookmark/new/', {'url': '/bookmark/'}),
-    ('_continue_editing', '/bookmark/edit/', {'id': '1'}),
+    ('_continue_editing', '/bookmark/edit/', {'id': '1', 'url': '/bookmark/'}),
 ])
 def test_update_redirect(bukudb, client, redirect, uri, args):
     _add_rec(bukudb, 'http://example.org')
@@ -412,22 +412,22 @@ _DICT = {
     'en': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Home', 'Bookmarks', 'Tags', 'Statistic'],
            f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()': ['List (1)', 'Create', 'Random', 'Reorder', 'Add Filter', '10 items'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['View Record', 'Edit Record'],
-           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},
+           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete Record']},
     'de': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Start', 'Lesezeichen', 'Schilder', 'Statistik'],
            f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()':
                ['Liste (1)', 'Erstellen', 'Zufälliger', 'Neu anordnen', 'Filter hinzufügen', '10 Elemente'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Eintrag ansehen', 'Eintrag bearbeiten'],
-           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},  # ['Datensatz löschen']},
+           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Datenzatz löschen']},
     'fr': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Accueil', 'Signets', 'Étiquettes', 'Statistique'],
            f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()':
-               ['Liste (1)', 'Créer', 'Aléatoire', 'Réorganiser', 'Ajouter un filtre', '10 items'],
+               ['Liste (1)', 'Créer', 'Aléatoire', 'Réorganiser', 'Ajouter un filtre', '10 articles'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Afficher L\'enregistrement', 'Modifier enregistrement'],
-           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},  # ['Supprimer l\'enregistrement']},
+           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Supprimer l\'enregistrement']},
     'ru': {f'//ul{xpath_cls("nav navbar-nav")}/li/a/text()': ['Главная', 'Закладки', 'Теги', 'Статистика'],
            f'//ul{xpath_cls("nav nav-tabs")}/li/a/text()':
                ['Список (1)', 'Создать', 'Случайная', 'Изменить порядок', 'Добавить Фильтр', '10 элементы'],
            f'//td{xpath_cls("list-buttons-column")}/a/@title': ['Просмотр записи', 'Редактировать запись'],
-           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Delete record']},  # ['Удалить запись']},
+           f'//td{xpath_cls("list-buttons-column")}/form/button/@title': ['Удалить запись']},
 }
 locale = env_fixture('BUKUSERVER_LOCALE', params=['en', 'de', 'fr', 'ru', None])
 


### PR DESCRIPTION
closes #753:
* updating Flask-Admin in deps to v2 + fixing problems caused by the change
* removing dependency on `flask_babelex` (as per Flask-Admin changes)

also:
* adding a `locales` extra to support installing bukuserver with locales support  
  (e.g. `pipx install buku[server,locales]`)

> [!NOTE]
> Flask-Admin v2 includes a fix for the Bootstrap4 dialog bug (as mentioned in #773).
