### PR TITLE
Fix readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,5 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - docs
+  - pip install --upgrade pip
+  - pip install .[locales,server] --group docs


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/12594

This was still trying to install the `docs` extra which is now a dependency group. Readthedocs doesn't have a top-level key for this but [suggests](https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-from-dependency-groups) to just install manually with pip
