### PR TITLE
adding Sec-Fetch-Mode header

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -4283,6 +4283,7 @@ def gen_headers():
     MYHEADERS = {
         'Accept-Encoding': 'gzip,deflate',
         'User-Agent': USER_AGENT,
+        'Sec-Fetch-Mode': 'navigate',
         'Accept': '*/*',
         'Cookie': '',
         'DNT': '1'

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -104,11 +104,12 @@ def test_gen_headers():
     import buku
 
     exp_myheaders = {
-        "Accept-Encoding": "gzip,deflate",
-        "User-Agent": buku.USER_AGENT,
-        "Accept": "*/*",
-        "Cookie": "",
-        "DNT": "1",
+        'Accept-Encoding': 'gzip,deflate',
+        'User-Agent': buku.USER_AGENT,
+        'Sec-Fetch-Mode': 'navigate',
+        'Accept': '*/*',
+        'Cookie': '',
+        'DNT': '1',
     }
     buku.gen_headers()
     assert buku.MYPROXY is None


### PR DESCRIPTION
closes #879:
* when generating headers to be used in `fetch_data()` requests, `Sec-Fetch-Mode` is included [to indicate user navigation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode#navigate)

_(this only makes a difference if the website admin has decided to put this specific requirement on incoming requests)_

### Screenshots

(before)
![fetch was blocked](https://github.com/user-attachments/assets/16c1763f-2b02-4c6a-8ce5-0ada419bb882)

(after)
![fetch succeeded](https://github.com/user-attachments/assets/b6ec3a89-a28c-4072-865c-2f7bbaa0370b)