### PR TITLE
fix: prevent open redirect in bookmark swap endpoint

### DIFF
--- a/bukuserver/views.py
+++ b/bukuserver/views.py
@@ -318,7 +318,11 @@ class BookmarkModelView(BaseModelView, ApplyFiltersMixin):
     def swap(self):
         form = forms.SwapForm()
         self.bukudb.swap_recs(form.id1.data, form.id2.data)
-        return redirect(request.form.get('url', url_for('bookmark.index_view')))
+        # Prevent open redirect: validate URL is relative
+        redirect_url = request.form.get('url', url_for('bookmark.index_view'))
+        if redirect_url.startswith('//') or '://' in redirect_url:
+            redirect_url = url_for('bookmark.index_view')
+        return redirect(redirect_url)
 
     def scaffold_list_columns(self):
         return [x.name.lower() for x in BookmarkField]


### PR DESCRIPTION
## Summary

Prevent open redirect in the bukuserver bookmark swap endpoint.

## Problem

The swap endpoint redirects to a user-supplied `url` form field without validation:

```python
return redirect(request.form.get('url', url_for('bookmark.index_view')))
```

An attacker can craft a form submission with `url=https://evil.com` to redirect users to external sites after the swap operation.

## Fix

Validate the redirect URL is a relative path:

```python
redirect_url = request.form.get('url', url_for('bookmark.index_view'))
if redirect_url.startswith('//') or '://' in redirect_url:
    redirect_url = url_for('bookmark.index_view')
return redirect(redirect_url)
```

## Impact

- **Type**: Open Redirect (CWE-601)
- **Affected endpoint**: `POST /swap` in bukuserver
- **OWASP**: A01:2021 — Broken Access Control