### PR TITLE
adding autoimport support for multiple/custom Firefox profile directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,9 @@ POWER TOYS:
       --ai                 auto-import bookmarks from web browsers
                            Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
                            (Firefox profile can be specified using
-                           environment variable FIREFOX_PROFILE)
+                           environment variable FIREFOX_PROFILE;
+                           Firefox profiles directory can be specified using
+                           environment variable FIREFOX_PROFILES_DIR)
       -e, --export file    export bookmarks to Firefox format HTML
                            export XBEL, if file ends with '.xbel'
                            export Markdown, if file ends with '.md'

--- a/buku.1
+++ b/buku.1
@@ -225,7 +225,7 @@ Decrypt (unlock) the DB file with
 .SH POWER OPTIONS
 .TP
 .BI \--ai
-Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE.)
+Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE; Firefox profiles directory can be specified using environment variable FIREFOX_PROFILES_DIR.)
 .TP
 .BI \-e " " \--export " file"
 Export bookmarks to Firefox bookmarks formatted HTML. Works with all search options.

--- a/buku.py
+++ b/buku.py
@@ -2885,7 +2885,7 @@ class BukuDb:
                     add_parent_folder_as_tag):
                 self.add_rec(*item)
 
-    def auto_import_from_browser(self, firefox_profile=None):
+    def auto_import_from_browser(self, firefox_profile=None, firefox_profiles_dir=None):
         """Import bookmarks from a browser default database file.
 
         Supports Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge.
@@ -2902,27 +2902,29 @@ class BukuDb:
             vi_bm_db_path = '~/.config/vivaldi/Default/Bookmarks'
             br_bm_db_path = '~/.config/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/.config/microsoft-edge/Default/Bookmarks'
-            default_ff_folder = '~/.mozilla/firefox'
+            _xdg_config = os.getenv('XDG_CONFIG_HOME') or '~/.config'
+            default_ff_folders = ['~/.mozilla/firefox', os.path.join(_xdg_config, 'mozilla/firefox')]
         elif sys.platform == 'darwin':
             gc_bm_db_path = '~/Library/Application Support/Google/Chrome/Default/Bookmarks'
             cb_bm_db_path = '~/Library/Application Support/Chromium/Default/Bookmarks'
             vi_bm_db_path = '~/Library/Application Support/Vivaldi/Default/Bookmarks'
             br_bm_db_path = '~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/Library/Application Support/Microsoft Edge/Default/Bookmarks'
-            default_ff_folder = '~/Library/Application Support/Firefox'
+            default_ff_folders = ['~/Library/Application Support/Firefox']
         elif sys.platform == 'win32':
             gc_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Google/Chrome/User Data/Default/Bookmarks')
             cb_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Chromium/User Data/Default/Bookmarks')
             vi_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Vivaldi/User Data/Default/Bookmarks')
             br_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/BraveSoftware/Brave-Browser/User Data/Default/Bookmarks')
             me_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Microsoft/Edge/User Data/Default/Bookmarks')
-            default_ff_folder = os.path.expandvars('%APPDATA%/Mozilla/Firefox/')
+            default_ff_folders = [os.path.expandvars('%APPDATA%/Mozilla/Firefox/')]
         else:
             LOGERR('buku does not support {} yet'.format(sys.platform))
             self.close_quit(1)
             return  # clarifying execution interrupt for the linter
 
-        ff_bm_db_paths = get_firefox_db_paths(default_ff_folder, firefox_profile)
+        ff_folders = ([firefox_profiles_dir] if firefox_profiles_dir else default_ff_folders)
+        ff_bm_db_paths = get_firefox_db_paths(*ff_folders, specified=firefox_profile)
 
         if self.chatty:
             resp = input('Generate auto-tag (YYYYMonDD)? (y/n): ')
@@ -3606,10 +3608,14 @@ def get_firefox_profile_names(path):
     LOGDBG('get_firefox_profile_names(): {} does not exist'.format(path))
     return profiles
 
-def get_firefox_db_paths(default_ff_folder, specified=None):
-    profiles = ([specified] if specified else get_firefox_profile_names(default_ff_folder))
-    _profile_path = lambda s: (s if os.path.isabs(s) else os.path.join(default_ff_folder, s))
-    return {s: os.path.join(_profile_path(s), 'places.sqlite') for s in profiles}
+def get_firefox_db_paths(*default_ff_folders, specified=None):
+    _profile_path = lambda f, s: (s if os.path.isabs(s) else os.path.join(f, s))
+    result = {}
+    for folder in default_ff_folders:
+        profiles = ([specified] if specified else get_firefox_profile_names(folder))
+        result.update({s: os.path.join(_profile_path(folder, s), 'places.sqlite')
+                       for s in profiles if s not in result})
+    return result
 
 
 def walk(root):
@@ -5998,7 +6004,9 @@ POSITIONAL ARGUMENTS:
         description='''    --ai                 auto-import bookmarks from web browsers
                          Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
                          (Firefox profile can be specified using
-                         environment variable FIREFOX_PROFILE)
+                         environment variable FIREFOX_PROFILE;
+                         Firefox profiles directory can be specified using
+                         environment variable FIREFOX_PROFILES_DIR)
     -e, --export file    export bookmarks to Firefox format HTML
                          export XBEL, if file ends with '.xbel'
                          export Markdown, if file ends with '.md'
@@ -6520,7 +6528,8 @@ POSITIONAL ARGUMENTS:
 
     # Import bookmarks from browser
     if args.ai:
-        bdb.auto_import_from_browser(firefox_profile=os.environ.get('FIREFOX_PROFILE'))
+        bdb.auto_import_from_browser(firefox_profile=os.environ.get('FIREFOX_PROFILE'),
+                                     firefox_profiles_dir=os.environ.get('FIREFOX_PROFILES_DIR'))
 
     # Open URL in browser
     if args.open is not None:

--- a/tests/test_buku.py
+++ b/tests/test_buku.py
@@ -908,17 +908,22 @@ def test_get_firefox_profile_names(_os_path_exists, profiles, expected):
         assert buku.get_firefox_profile_names('') == expected
 
 @pytest.mark.parametrize('profiles, specified, expected', [
-    (['foo', '/bar/baz'], None, {
+    ({'~/profiles': ['foo', '/bar/baz']}, None, {
         'foo': os.path.join('~/profiles', 'foo', 'places.sqlite'),
         '/bar/baz': os.path.join('/bar/baz', 'places.sqlite'),
     }),
-    (['foo', '/bar/baz'], 'qux', {'qux': os.path.join('~/profiles', 'qux', 'places.sqlite')}),
-    ([], '/grue/xyzzy', {'/grue/xyzzy': os.path.join('/grue/xyzzy', 'places.sqlite')}),
+    ({'~/profiles': ['foo', '/bar/baz']}, 'qux', {'qux': os.path.join('~/profiles', 'qux', 'places.sqlite')}),
+    ({'~/profiles': []}, '/grue/xyzzy', {'/grue/xyzzy': os.path.join('/grue/xyzzy', 'places.sqlite')}),
+    ({'~/profiles': ['foo', 'bar'], '~/.config/profiles': ['foo', 'baz']}, None, {
+        'foo': os.path.join('~/profiles', 'foo', 'places.sqlite'),  # for collisions, prefer 1st dir
+        'bar': os.path.join('~/profiles', 'bar', 'places.sqlite'),
+        'baz': os.path.join('~/.config/profiles', 'baz', 'places.sqlite'),
+    }),
 ])
 def test_get_firefox_db_paths(profiles, specified, expected):
-    with mock.patch('buku.get_firefox_profile_names', return_value=profiles):
+    with mock.patch('buku.get_firefox_profile_names', side_effect=profiles.values()):
         import buku
-        assert buku.get_firefox_db_paths('~/profiles', specified) == expected
+        assert buku.get_firefox_db_paths(*profiles.keys(), specified=specified) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
resolves #882:
* when using `--ai` (autoimport) CLI command on Linux, the XDG profiles directory is now being checked as well ([as per the changes introduced in Firefox release 147.0](https://bugzilla.mozilla.org/show_bug.cgi?id=259356))
  - **Note:** based on the current behaviour (tested on Firefox 149.0), XDG directory is the _default_ location where Firefox saves its config files, **but** the legacy location _takes priority_ when it exists (meaning that when both exist, the legacy directory is used); though apparently the latter can be toggled off at will :thinking:  
    After considering this behaviour, I've decided to list profiles from both, with preference to legacy in case of a collision.

_[…Better late than never :melting_face:]_

also:
* adding a `FIREFOX_PROFILES_DIR` environment variable to specify a custom folder to look for Firefox profiles in (this incidentally allows importing from arbitrary [Firefox-based browsers](https://en.wikipedia.org/wiki/Category:Web_browsers_based_on_Firefox))

### Screenshots

<details><summary><em><code>profiles.ini</code> contents in the XDG directory</em></summary>

![one default profile is listed](https://github.com/user-attachments/assets/b15663b4-ab65-4244-ba4e-bede39a38cd7)
</details>

(before)
![only the legacy profiles dir is used](https://github.com/user-attachments/assets/522eee93-0b44-4a5d-9d31-dc244309562b)
(after)
![both legacy and XDG dirs are used](https://github.com/user-attachments/assets/6928073f-58a8-460a-a08b-7580e29fc493)

<details><summary><h4>Using <code>FIREFOX_PROFILES_DIR</code> environment variable</h4></summary>

* specifying custom location (e.g. to ignore other places):
  ![using only the legacy directory](https://github.com/user-attachments/assets/b9e847cc-5109-420b-9509-5d347ddfcb4a)
* importing from arbitrary Firefox-based browsers (e.g. [Zen](https://en.wikipedia.org/wiki/Zen_Browser), [Floorp](https://en.wikipedia.org/wiki/Floorp))
  ![two import commands, each providing respective location for Zen and Floorp profiles dir](https://github.com/user-attachments/assets/a4accfe5-97b7-49c7-8741-57ddffba0c0b)
</details>