### PR TITLE
chore: improve buku maintenance path

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,18 +39,31 @@ def exit():
 
 
 def test_version(BukuDb, piped_input, capsys):
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         buku.main(['--version'])
+    assert exc_info.value.code == 0
     assert capsys.readouterr().out.splitlines() == [buku.__version__]
 
 def test_usage(BukuDb, piped_input, monkeypatch, capsys):
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         buku.main(['--unknown'], program_name='buku')
     BukuDb.assert_not_called()
+    assert exc_info.value.code == 2
     assert capsys.readouterr().err.splitlines() == [
         'usage: buku [OPTIONS] [KEYWORD [KEYWORD ...]]',
         'buku: error: unrecognized arguments: --unknown',
     ]
+
+@pytest.mark.parametrize('value,msg', [
+    ('2', 'invalid choice:'),
+    ('foo', 'invalid int value:'),
+])
+def test_immutable_invalid(BukuDb, piped_input, capsys, value, msg):
+    with pytest.raises(SystemExit) as exc_info:
+        buku.main(['--add', 'https://example.com', '--immutable', value], program_name='buku')
+    BukuDb.assert_not_called()
+    assert exc_info.value.code == 2
+    assert msg in capsys.readouterr().err
 
 @pytest.mark.parametrize('argv', [['--help'], ['foo', 'bar', '--help']])
 def test_help(BukuDb, exit, piped_input, argv):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import os
+from typing import Optional, Set
 
 from urllib3 import HTTPResponse
 
@@ -20,7 +21,7 @@ def _add_rec(db, *args, **kw):
     """Use THIS instead of db.add_rec() UNLESS you want to wait for unnecessary network requests."""
     return db.add_rec(*args, fetch=False, **kw)
 
-def _tagset(s):
+def _tagset(s: Optional[str]) -> Set[str]:
     return set(x for x in str(s or '').lower().split(',') if x)
 
 def append(buffer, text):


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/util.py, tests/test_cli.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.