### PR TITLE
updating a functional test to match behaviour changes made in Flask-Admin v2.1.0

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -204,7 +204,7 @@ def test_create_and_fetch(bukudb, monkeypatch, client, fetch, title, desc):
 @pytest.mark.gui
 @pytest.mark.slow
 @pytest.mark.parametrize('redirect, uri, args', [
-    ('_add_another', '/bookmark/new/', {}),
+    ('_add_another', '/bookmark/new/', {'url': '/bookmark/'}),
     ('_continue_editing', '/bookmark/edit/', {'id': '1', 'url': '/bookmark/'}),
 ])
 def test_create_redirect(client, redirect, uri, args):


### PR DESCRIPTION
Turns out the test started failing due to changes introduced in Flask-Admin release [v2.1.0](https://github.com/pallets-eco/flask-admin/releases/tag/v2.1.0) (see pallets-eco/flask-admin#2716)

## Screenshots

### before (Flask-Admin v2.0.2)
![clicking Save-and-Add-Another button in Create-Bookmark form](https://github.com/user-attachments/assets/398697bc-4170-4f5b-b91c-17311c80e357)
![response URL contains no redirect-URL parameter](https://github.com/user-attachments/assets/177b2553-95d4-4aab-86c9-e07af9fcc6b5)

### after (Flask-Admin v2.1.0)
![clicking Save-and-Add-Another button in Create-Bookmark form](https://github.com/user-attachments/assets/1a0b0c92-f864-461d-8788-8c58775b0a93)
![response URL contains a redirect-URL parameter](https://github.com/user-attachments/assets/74557240-9556-4e42-97cc-2e240589ab64)
