### PR TITLE
fix: apply sort order in interactive prompt

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -607,11 +607,13 @@ class BukuDb:
         """Converts field list to ordering parameters (for DB query or entity list sorting).
         Fields are listed in priority order, with '+'/'-' prefix signifying ASC/DESC; assuming ASC if not specified.
         Other than names from DB, you can pass those from JSON export."""
+        fields = list(fields or [])  # handling nils and generators
         _field = lambda s: re.sub(r'^[+-]?(#)? *', r'\1', s).rstrip().lower()
-        tags = {_field(s) for s in (fields or []) if re.fullmatch(r'[+-]?#[^,]+', s)}
+        tags = {_field(s) for s in fields if re.fullmatch(r'[+-]?#[^,]+', s)}
         names = {'index': 'id', 'uri': 'url', 'description': 'desc', **({'title': 'metadata'} if for_db else {'metadata': 'title'})}
         valid = list(names) + list(names.values()) + ['tags', 'netloc'] + list(tags)
-        _fields = [(_field(s), not s.startswith('-')) for s in (fields or [])]
+        LOGDBG('ordering: fields=%s, valid=%s', fields, valid)
+        _fields = [(_field(s), not s.startswith('-')) for s in fields]
         _fields = [(names.get(field, field), direction) for field, direction in _fields if field in valid]
         return _fields or [('id', True)]
 
@@ -4779,12 +4781,15 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
             _fields = {'metadata': 'title', **JSON_FIELDS}
             _order = bdb._ordering(filter(None, re.split(r'[,\s]+', nav[2:].strip())))
             order_ = [('+' if asc else '-') + _fields.get(s, s) for s, asc in _order]
-            if nav.startswith('v '):
-                order = order_
-                print('order', ', '.join(order))
-            else:
+            if nav.startswith('v! '):
                 bdb.reorder(order_)
                 print('Reindexed bookmarks to match order:', ', '.join(order_))
+            else:
+                order = order_
+                print('order', ', '.join(order))
+                if results:
+                    results = bdb._sort(results, order)
+                    cur_index = next_index = 0
             continue
 
         # Toggle GUI browser with 'O'

--- a/tests/test_bukuDb.py
+++ b/tests/test_bukuDb.py
@@ -1703,6 +1703,19 @@ def test_sort_and_reorder(bukuDb, fields, ignore_case, expected):
     bdb.reorder(fields, ignore_case=ignore_case)
     assert [x.url for x in bdb.get_rec_all()] == expected
 
+
+@pytest.mark.parametrize('fields, for_db, expected', [
+    (lambda: filter(None, ['url']), True, [('url', True)]),
+    (lambda: filter(None, ['+url', '-id']), True, [('url', True), ('id', False)]),
+    (lambda: None, True, [('id', True)]),
+    (lambda: [], True, [('id', True)]),
+    (lambda: ['+title'], False, [('title', True)]),
+    (lambda: ['+title'], True, [('metadata', True)]),
+])
+def test_ordering(bukuDb, fields, for_db, expected):
+    assert bukuDb()._ordering(fields(), for_db=for_db) == expected
+
+
 @pytest.mark.parametrize('ignore_case, fields, expected', [
     (True, ['+id'], 'id ASC'),
     (True, [], 'id ASC'),


### PR DESCRIPTION
### Problem
closes #895
The interactive `v` command updated the sort order but did not re-sort
or re-display the current list. Parsed sort fields were also dropped,
so commands like `v url` fell back to the default index order, because `_ordering` needs to iterate fields twice.
### Fix
- Added change to _ordering() provided by @LeXofLeviafan 
- Re-sort with `_sort()`.
- Add test for `v` command, and _ordering().
### Tests
- `pytest tests/test_bukuDb.py::test_ordering`
```
buku (? for help) [buku-smoke] v url
order +uri
buku (? for help) [buku-smoke] v +url
order +uri
buku (? for help) [buku-smoke] v title
order +title
buku (? for help) [buku-smoke] v description
order +description
buku (? for help) [buku-smoke] v tag
order +index
buku (? for help) [buku-smoke] v tags
order +tags
```