### PR TITLE
[jarun#894] fix: cannot append or remove tags for single record at pr…

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -2509,14 +2509,14 @@ class BukuDb:
                 for id in db_id_list:
                     if is_int(id) and int(id) > 0:
                         if flag == 1:
-                            if self.append_tag_at_index(id, tags, True):
+                            if self.append_tag_at_index(int(id), tags, True):
                                 update_count += 1
                         elif flag == 2:
                             tags = parse_tags([tags])
                             self.cur.execute(query, (tags, id,))
                             update_count += self.cur.rowcount
                         else:
-                            self.delete_tag_at_index(id, tags, True)
+                            self.delete_tag_at_index(int(id), tags, True)
                             update_count += 1
                     elif '-' in id:
                         vals = [int(x) for x in id.split('-')]


### PR DESCRIPTION
closes #894

### Problem
At the interactive prompt, `g <tag> >> <id>` and `g <tag> << <id>` silently fail for a single record ID (e.g. `100`) but work for a range (`100-100`).  `id` was passed as a string to `append_tag_at_index` / `delete_tag_at_index`

### Fix
Casting to `int(id)` in set_tag fixes the mismatch.