### PR TITLE
Fix interactive prompt: keep reverse-video escape inside readline non-printing markers

### DIFF
--- a/buku.py
+++ b/buku.py
@@ -4695,7 +4695,7 @@ def prompt(obj, results, noninteractive=False, deep=False, listtags=False, sugge
             prompt_suffix = ''
             if bdb.dbfile != os.path.realpath(os.path.join(BukuDb.get_default_dbdir(), 'bookmarks.db')):
                 prompt_suffix = (f'[{bdb.dbname}] ' if not bdb.colorize else
-                                 f'\001\x1b[7\002m[{bdb.dbname}]\001\x1b[0m\002 ')
+                                 f'\001\x1b[7m\002[{bdb.dbname}]\001\x1b[0m\002 ')
             nav = read_in(PROMPTMSG + prompt_suffix)
             if not nav:
                 nav = read_in(PROMPTMSG + prompt_suffix)
@@ -6154,7 +6154,7 @@ POSITIONAL ARGUMENTS:
         setup_logger(LOGGER)
 
         # Enable prompt with reverse video
-        PROMPTMSG = '\001\x1b[7\002mbuku (? for help)\001\x1b[0m\002 '
+        PROMPTMSG = '\001\x1b[7m\002buku (? for help)\001\x1b[0m\002 '
 
     # Enable browser output in case of a text based browser
     if os.getenv('BROWSER') in TEXT_BROWSERS:


### PR DESCRIPTION
## Description
In the interactive prompt, after typing characters and pressing Backspace repeatedly, the **first** typed character cannot be deleted (the cursor/redisplay is off by one column).

The colored prompt brackets its ANSI escapes with readline's non-printing markers `\001` (`RL_PROMPT_START_IGNORE`) and `\002` (`RL_PROMPT_END_IGNORE`) so they aren't counted toward the prompt width. But in the reverse-video **open** sequence, `\002` is placed *before* the terminating `m` of `\x1b[7m`, leaving the `m` outside the ignore region:

```python
# before
PROMPTMSG = '\001\x1b[7\002mbuku (? for help)\001\x1b[0m\002 '
#                    ^^^^ \002 closes before the terminating `m`
```

The terminal still consumes `\x1b[7m` as an invisible SGR toggle, but readline counts the leftover `m` as one visible column. So readline computes the prompt as 19 columns wide when it renders as 18 — an off-by-one that shifts readline's idea of where input begins, so Backspace stops one column early. The reset code `\001\x1b[0m\002` is already wrapped correctly, which is why the error is exactly one column.

Fix — move `\002` to *after* the `m`, so the whole `\x1b[7m` is inside the markers:

```python
# after
PROMPTMSG = '\001\x1b[7m\002buku (? for help)\001\x1b[0m\002 '
```

Two occurrences are affected: `PROMPTMSG` (main reverse-video prompt) and the per-DB prompt suffix (`[{bdb.dbname}]`).

## Design notes
Purely a correction of the readline non-printing markers around the reverse-video SGR opener; no logic, API, or option changes. The closing `\x1b[0m` was already correctly bracketed and is left unchanged.

## Side effects
None expected. The change is inert when color is disabled (`--nc` / `NO_COLOR`), since that path uses the plain, escape-free `PROMPTMSG`. Not OS-specific — it's a readline redisplay issue reproducible wherever GNU readline is used.

## Test cases
Minimal repro (no buku needed) — before the fix, type a word then Backspace to the start; the first char can't be removed:

```python
import readline  # noqa: F401
prompt = '\001\x1b[7\002mbuku (? for help)\001\x1b[0m\002 '
input(prompt)
```

Manual verification with buku:

```
buku              # type "hello", hold Backspace -> clears fully, incl. first char
buku --db testdb  # exercises the [testdb] reverse-video suffix; backspace behaves too
```

Linting (per PR guidelines) — both clean on the change:

```
python3 -m flake8 buku.py
python3 -m pylint buku.py --rc-file tests/.pylintrc
```
