### PR TITLE
Remove unnecessary `py` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ tests = [
     "flake8>=3.4.1",
     "hypothesis>=6.0.0",
     "mypy-extensions==0.4.1",
-    "py>=1.5.0",
     "pylint>=1.7.2",
     "pytest-cov",
     "pytest-recording>=0.12.1",


### PR DESCRIPTION
Remove the dependency on `py`, as it is not used anywhere.  `py` is unmaintained (last release in 2021) and has known vulnerabilities.