### PR TITLE
Support Vivaldi's test versions ("Vivaldi Internal") as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get started right away, jump to the [Quickstart](#quickstart) section. `buku`
 ### Features
 
 - Store bookmarks with auto-fetched title, tags and description
-- Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge
+- Auto-import from Firefox, Google Chrome, Chromium, Vivaldi, Vivaldi Beta (Internal), Brave, and MS Edge
 - Open bookmarks and search results in browser
 - Browse cached page from the Wayback Machine
 - Text editor integration
@@ -227,7 +227,8 @@ ENCRYPTION OPTIONS:
 
 POWER TOYS:
       --ai                 auto-import bookmarks from web browsers
-                           Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
+                           Firefox, Chrome, Chromium, Vivaldi, Vivaldi
+                           Internal, Brave, Edge
                            (Firefox profile can be specified using
                            environment variable FIREFOX_PROFILE;
                            Firefox profiles directory can be specified using

--- a/buku.1
+++ b/buku.1
@@ -225,7 +225,7 @@ Decrypt (unlock) the DB file with
 .SH POWER OPTIONS
 .TP
 .BI \--ai
-Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, Brave, and MS Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE; Firefox profiles directory can be specified using environment variable FIREFOX_PROFILES_DIR.)
+Auto-import bookmarks from Firefox, Google Chrome, Chromium, Vivaldi, Vivaldi Internal, Brave, and MS Edge browsers. (Firefox profile can be specified using environment variable FIREFOX_PROFILE; Firefox profiles directory can be specified using environment variable FIREFOX_PROFILES_DIR.)
 .TP
 .BI \-e " " \--export " file"
 Export bookmarks to Firefox bookmarks formatted HTML. Works with all search options.

--- a/buku.py
+++ b/buku.py
@@ -6011,11 +6011,11 @@ POSITIONAL ARGUMENTS:
         title='POWER TOYS',
         description='''    --ai                 auto-import bookmarks from web browsers
                          Firefox, Chrome, Chromium, Vivaldi, Vivaldi
-                         Internal, Brave, Edge (Firefox profile can be
-                         specified using  environment variable
-                         FIREFOX_PROFILE; Firefox profiles directory can
-                         be specified using environment variable
-                         FIREFOX_PROFILES_DIR)
+                         Internal, Brave, Edge
+                         (Firefox profile can be specified using
+                         environment variable FIREFOX_PROFILE;
+                         Firefox profiles directory can be specified using
+                         environment variable FIREFOX_PROFILES_DIR)
     -e, --export file    export bookmarks to Firefox format HTML
                          export XBEL, if file ends with '.xbel'
                          export Markdown, if file ends with '.md'

--- a/buku.py
+++ b/buku.py
@@ -2902,6 +2902,7 @@ class BukuDb:
             gc_bm_db_path = '~/.config/google-chrome/Default/Bookmarks'
             cb_bm_db_path = '~/.config/chromium/Default/Bookmarks'
             vi_bm_db_path = '~/.config/vivaldi/Default/Bookmarks'
+            vs_bm_db_path = '~/.config/vivaldi-internal/Default/Bookmarks'
             br_bm_db_path = '~/.config/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/.config/microsoft-edge/Default/Bookmarks'
             _xdg_config = os.getenv('XDG_CONFIG_HOME') or '~/.config'
@@ -2910,6 +2911,7 @@ class BukuDb:
             gc_bm_db_path = '~/Library/Application Support/Google/Chrome/Default/Bookmarks'
             cb_bm_db_path = '~/Library/Application Support/Chromium/Default/Bookmarks'
             vi_bm_db_path = '~/Library/Application Support/Vivaldi/Default/Bookmarks'
+            vs_bm_db_path = '~/Library/Application Support/Vivaldi Internal/Default/Bookmarks'
             br_bm_db_path = '~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Bookmarks'
             me_bm_db_path = '~/Library/Application Support/Microsoft Edge/Default/Bookmarks'
             default_ff_folders = ['~/Library/Application Support/Firefox']
@@ -2917,6 +2919,7 @@ class BukuDb:
             gc_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Google/Chrome/User Data/Default/Bookmarks')
             cb_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Chromium/User Data/Default/Bookmarks')
             vi_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Vivaldi/User Data/Default/Bookmarks')
+            vs_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Vivaldi Internal/User Data/Default/Bookmarks')
             br_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/BraveSoftware/Brave-Browser/User Data/Default/Bookmarks')
             me_bm_db_path = os.path.expandvars('%LOCALAPPDATA%/Microsoft/Edge/User Data/Default/Bookmarks')
             default_ff_folders = [os.path.expandvars('%APPDATA%/Mozilla/Firefox/')]
@@ -2944,7 +2947,7 @@ class BukuDb:
             resp = 'y'
 
             chrome_based = {'Google Chrome': gc_bm_db_path, 'Chromium': cb_bm_db_path, 'Vivaldi': vi_bm_db_path,
-                            'Brave': br_bm_db_path}
+                            'Vivaldi Internal': vs_bm_db_path, 'Brave': br_bm_db_path}
             for name, path in chrome_based.items():
                 try:
                     if os.path.isfile(os.path.expanduser(path)):
@@ -6007,11 +6010,12 @@ POSITIONAL ARGUMENTS:
     power_grp = argparser.add_argument_group(
         title='POWER TOYS',
         description='''    --ai                 auto-import bookmarks from web browsers
-                         Firefox, Chrome, Chromium, Vivaldi, Brave, Edge
-                         (Firefox profile can be specified using
-                         environment variable FIREFOX_PROFILE;
-                         Firefox profiles directory can be specified using
-                         environment variable FIREFOX_PROFILES_DIR)
+                         Firefox, Chrome, Chromium, Vivaldi, Vivaldi
+                         Internal, Brave, Edge (Firefox profile can be
+                         specified using  environment variable
+                         FIREFOX_PROFILE; Firefox profiles directory can
+                         be specified using environment variable
+                         FIREFOX_PROFILES_DIR)
     -e, --export file    export bookmarks to Firefox format HTML
                          export XBEL, if file ends with '.xbel'
                          export Markdown, if file ends with '.md'


### PR DESCRIPTION
It's been a while since I've been doing Buku stuff. However, I have an urgent need to migrate (back) to Buku now. Life's hard. So here's support for my current daily driver browser, Vivaldi "Sopranos" (= Vivaldi Internal, the beta builds). Caveat: I don't have (nor do I desire to have) a Linux machine, so I wouldn't bet on having got the path right.